### PR TITLE
Restructure optimization

### DIFF
--- a/PyART/analysis/opt_ic.py
+++ b/PyART/analysis/opt_ic.py
@@ -305,7 +305,6 @@ class Optimizer(object):
                 print(f'   ---> writing on file: {json_file}')
                 creating_new_file = True
 
-        print(data)
         with open(json_file, 'w') as file:
             file.write(json.dumps(data,indent=2))
 
@@ -326,7 +325,7 @@ class Optimizer(object):
 
         # map the ICs (and the other intrinsic pars) to the EOB parameters
         mapped_ids = self.map_function({**ICs, **sub_meta})
-        if self.kind_ic=='E0pph0':
+        if 'H_hyp' in mapped_ids:
             if self.r0_eob == 'read':
                 # start close to the NR value, a little earlier
                 mapped_ids['r_hyp'] = ref_meta['r0']*1.1

--- a/PyART/analysis/opt_ic.py
+++ b/PyART/analysis/opt_ic.py
@@ -11,13 +11,15 @@ from ..utils       import utils as ut
 class Optimizer(object):
     """
     Class to compute EOB initial data that minimize mismatch
-    with reference waveform
+    with reference waveform.
     """
     def __init__(self,
                  ref_Waveform,
 
                  # option for dual annealing
-                 kind_ic      = 'E0pph0', # implemented: e0f0, E0pph0
+                 kind_ic      = 'E0pph0',           # kind of ICs to optimize over
+                 vrs          = ['H_hyp', 'j_hyp'], # variables to optimize over, default is ['H_hyp', 'j_hyp']
+                 map_function = None,               # function to map variables to EOB parameters
                  use_nqc      = True,
                  opt_seed     = 190521,
                  opt_maxfun   = 100,
@@ -28,13 +30,12 @@ class Optimizer(object):
                  opt_good_mm  = 5e-3,  # interrupt opt-iters if mm is below this threshold
 
                  # Option for bounds and iterations
-                 opt_bounds   = None,  # specify bounds (None or [[x1,x2],[y1,y2]] )
+                 opt_bounds   = None,  # specify bounds (None or {'key1': [x1,x2], 'key2': [y1,None], ...} )
                  eps_initial  = 1e-2,  # initial bound eps, used if some opt bounds are not specified
                  eps_factor   = 2,     # increase-factor for eps at each eps-iter
                  eps_max_iter = 1,     # If true, iterate on eps-bounds
                  eps_bad_mm   = 0.1,   # if after opt_max_iter(s) we are still above this threshold, 
                                        # increase bound-eps (if eps_max_iter>1)
-                 
                  # cache
                  use_matcher_cache = False, 
 
@@ -58,6 +59,7 @@ class Optimizer(object):
         
         self.opt_max_iter = opt_max_iter
         self.opt_good_mm  = opt_good_mm
+        self.opt_data     = None
 
         self.opt_bounds   = opt_bounds
         self.eps_initial  = eps_initial
@@ -70,7 +72,8 @@ class Optimizer(object):
         self.json_file    = json_file
         self.overwrite    = overwrite
         self.verbose      = verbose
-        
+        self.debug        = debug
+
         # mismatch settings
         self.mm_settings = Matcher.__default_parameters__(0) 
         if isinstance(mm_settings, dict):
@@ -80,25 +83,21 @@ class Optimizer(object):
             print("Warning: using the option 'cut_longer' during optimization should be avoided!")
         if not self.mm_settings['cut_second_waveform'] and self.verbose:
             print("Warning: using the option 'cut_second_waveform' during optimization is strongly suggested!")
-        
-        # set up things according to IC-kind
-        if kind_ic=='e0f0':
-            e0_nr = self.ref_Waveform.metadata['e0']
-            if e0_nr is None or e0_nr>=1:
-                if self.verbose: print('Invalid e0 in NR waveform! Overwriting with e0=0.5')
-                self.ref_Waveform.metadata['e0'] = 0.5
-            ic_keys = ['e0', 'f0']
-        elif kind_ic=='E0pph0':
-            ic_keys = ['E0byM', 'pph0']
-        else:
-            raise ValueError('Unknown IC kind: {kind_ic}')
-        self.ic_keys = ic_keys
-        
+                          
+        # decide IC vars based on kind_ic
+        self.__set_variables(vrs)
+        if map_function is not None:
+            if self.map_function is None:
+                self.map_function = map_function
+            else:
+                print('Warning: map_function is not None, but kind_ic is not "choose"')
+                print('         user-input map_function will be ignored.')            
+
         # update bounds
         if self.opt_bounds is None:
-            self.opt_bounds = [[None,None],[None,None]]
+            self.opt_bounds = {var: [None, None] for var in self.opt_vars}
         self.__update_bounds(eps=eps_initial)
-          
+
         if verbose:
             q    = ref_Waveform.metadata['q']
             chi1 = ref_Waveform.metadata['chi1z'] 
@@ -113,35 +112,24 @@ class Optimizer(object):
             print(f'Reference waveform : {ref_Waveform.metadata["name"]}')
             print(f'(q, chi1z, chi2z)  : ({q:.2f}, {chi1:.2f}, {chi2:.2f})')
             print(f'binary type        : {flags_str}')
-            print(f'Variables for ICs  : {ic_keys[0]}, {ic_keys[1]}')
+            print(f'Variables for ICs  : {self.opt_vars}')
             print(' ')
 
         mm_data  = self.load_or_create_mismatches()
         ref_name = self.ref_Waveform.metadata['name']
         
-        opt_data      = None
-        self.opt_data = opt_data
-
         run_optimization = True
+        opt_data = None
         if ref_name in mm_data['mismatches']:
             opt_data = mm_data['mismatches'][ref_name]
-            # TODO: commented this part. Seems useless. Double check 
-#            opt_data['q']     = self.ref_Waveform.metadata['q']
-#            opt_data['chi1x'] = self.ref_Waveform.metadata['chi1x']
-#            opt_data['chi1y'] = self.ref_Waveform.metadata['chi1y']
-#            opt_data['chi1z'] = self.ref_Waveform.metadata['chi1z']
-#            opt_data['chi2x'] = self.ref_Waveform.metadata['chi2x']
-#            opt_data['chi2y'] = self.ref_Waveform.metadata['chi2y']
-#            opt_data['chi2z'] = self.ref_Waveform.metadata['chi2z']
-#            mm_data['mismatches'][ref_name] = opt_data
-#            with open(json_file, 'w') as file:
-#                file.write(json.dumps(mm_data,indent=2))
+
             if not overwrite or opt_data['mm_opt']<eps_bad_mm:
                 run_optimization = False
             if verbose: 
                 print(f'Loading mismatch from {self.json_file}')
-                print('Optimal ICs  : {:s}={:.5f}, {:s}:{:.5f}'.format(opt_data['kx'], opt_data['x_opt'],
-                                                                  opt_data['ky'], opt_data['y_opt']))
+                print('Optimal ICs  :')
+                for ky in self.opt_vars:
+                    print(f'                {ky:5s} : {opt_data[ky+"_opt"]:.15f}')
                 print('Original mm  : {:.3e}'.format(opt_data['mm0']))
                 print('Optimized mm : {:.3e}\n'.format(opt_data['mm_opt']))
         
@@ -158,7 +146,7 @@ class Optimizer(object):
                 if self.eps_max_iter>1 and self.verbose:
                     print(f'\n{asterisks}\nSearch bounds (eps) iteration  #{i:d}\n{asterisks}')
                  
-                # j-loop on different initial gueses 
+                # j-loop on different initial gueses
                 for j in range(1, self.opt_max_iter+1):
                     if self.verbose: print(f'{dashes}\nOptimization iteration #{j:d}\n{dashes}')
                     if i==1 and j==1 and opt_data is None: # if first iter of both loops
@@ -203,24 +191,42 @@ class Optimizer(object):
                 self.save_mismatches(mm_data)
         self.opt_data = opt_data
 
-        if debug:
-            self.mm_settings['debug'] = True
-            opt_Waveform = self.generate_EOB(ICs={self.ic_keys[0]:opt_data['x_opt'], 
-                                                  self.ic_keys[1]:opt_data['y_opt']})
-            self.match_against_ref(opt_Waveform)
+    def __set_variables(self, vrs):
+        """
+        Set the variables to optimize over depending on the kind of ICs
+        """
+        if self.kind_ic == 'choose':
+            self.opt_vars     = vrs
+            self.map_function = None # Needs to be defined by the user
+        elif self.kind_ic == 'e0f0':
+            self.opt_vars = ['e0', 'f0']
+            self.map_function = lambda x: {'ecc':x['e0'], 'f0':x['f0']} # map to EOB pars
+        elif self.kind_ic == 'E0pph0':
+            self.opt_vars = ['E0byM', 'pph0']
+            self.map_function = lambda x: {'H_hyp':x['E0byM'], 'J_hyp':x['pph0']}
+        else:
+            raise ValueError(f'Unknown kind of ICs: {self.kind_ic}')
         pass
-    
+
     def __update_bounds(self, eps=1e-2):
-        kx = self.ic_keys[0]
-        ky = self.ic_keys[1]
-        vx_ref = self.ref_Waveform.metadata[kx]
-        vy_ref = self.ref_Waveform.metadata[ky]
-        default_bounds = [ [vx_ref*(1-eps), vx_ref*(1+eps)],
-                           [vy_ref*(1-eps), vy_ref*(1+eps)] ]
-        for i in range(2):
+        """
+        Set the bounds for the optimization; if the bounds are not specified,
+        set them to the reference value (read from metadata) +/- eps
+        """
+        vls = []
+        for ky in self.opt_vars:
+            try:
+                vls.append(self.ref_Waveform.metadata[ky])
+            except KeyError:
+                print(f'WARNING: update bounds, {ky} not found in metadata. Setting to 1.')
+                vls.append(1)
+        
+        default_bounds = {ky: [vl*(1-eps), vl*(1+eps)] for ky,vl in zip(self.opt_vars, vls)}
+        
+        for ky in self.opt_vars:
             for j in range(2):
-                if self.opt_bounds[i][j] is None:
-                    self.opt_bounds[i][j] = default_bounds[i][j]
+                if self.opt_bounds[ky][j] is None:
+                    self.opt_bounds[ky][j] = default_bounds[ky][j]
         pass
 
     def load_or_create_mismatches(self): 
@@ -241,6 +247,7 @@ class Optimizer(object):
         # options to store/read in JSON 
         options = {'opt_maxfun'   : self.opt_maxfun, 
                    'kind_ic'      : self.kind_ic,
+                   'vars'         : self.opt_vars,
                    'mm_settings'  : loc_mm_settings,
                   } 
 
@@ -298,6 +305,7 @@ class Optimizer(object):
                 print(f'   ---> writing on file: {json_file}')
                 creating_new_file = True
 
+        print(data)
         with open(json_file, 'w') as file:
             file.write(json.dumps(data,indent=2))
 
@@ -308,64 +316,43 @@ class Optimizer(object):
 
     def generate_EOB(self, ICs={'f0':None, 'e0':None}):
         ref_meta = self.ref_Waveform.metadata
-        # define subset of info to generate EOB waveform
-        keys_to_use =  ['M', 'q', 'chi1x', 'chi1y', 'chi1z', 'chi2x', 'chi2y', 'chi2z']
-        sub_meta = {key: ref_meta[key] for key in keys_to_use}
-        
-        sub_meta['use_nqc'] = self.use_nqc
+        # Set all the intrinsic parameters that are not in ICs
+        default_intrinsic =  ['M', 'q', 'chi1x', 'chi1y', 'chi1z', 'chi2x', 'chi2y', 'chi2z']
+        for ic in ICs: 
+            if ic in default_intrinsic: default_intrinsic.remove(ic)
+        sub_meta = {key: ref_meta[key] for key in default_intrinsic}
+        sub_meta['use_nqc']  = self.use_nqc
+        sub_meta['ode_tmax'] = 2e+4
 
-        # kind-specific input
-        def return_IC(key):
-            if key not in ICs:
-                raise RuntimeError('Specify f0 in ICs!')
-            elif ICs[key] is None:
-                return ref_meta[key]
-            else:
-                return ICs[key]
-        
-        if self.kind_ic=='quasi-circ': # here only for testing
-            sub_meta['f0'] = return_IC('f0')
-        
-        elif self.kind_ic=='e0f0':
-            sub_meta['ecc'] = return_IC('e0')
-            sub_meta['f0']  = return_IC('f0')
-
-        elif self.kind_ic=='E0pph0':
-            sub_meta['H_hyp'] = return_IC('E0byM')
-            sub_meta['J_hyp'] = return_IC('pph0')
+        # map the ICs (and the other intrinsic pars) to the EOB parameters
+        mapped_ids = self.map_function({**ICs, **sub_meta})
+        if self.kind_ic=='E0pph0':
             if self.r0_eob == 'read':
                 # start close to the NR value, a little earlier
-                sub_meta['r_hyp'] = ref_meta['r0']*1.1
+                mapped_ids['r_hyp'] = ref_meta['r0']*1.1
             else:
-                sub_meta['r_hyp'] = self.r0_eob  # if None, it will be computed in the EOB model
-        else: 
-            raise ValueError(f'Unknown kind of ICs: {kind}')
-       
-        sub_meta['ode_tmax'] = 2e+4
-        # return generated EOB waveform 
+                if self.r0_eob is not None:
+                    if self.r0_eob < ref_meta['r0']:
+                        print(f'Warning: r0_eob={self.r0_eob} is smaller than the NR value r0={ref_meta["r0"]}')
+                        print('         Setting r0_eob to NR value')
+                        mapped_ids['r_hyp'] = ref_meta['r0']
+                    else:
+                        mapped_ids['r_hyp'] = self.r0_eob
+                mapped_ids['r_hyp']         = self.r0_eob  # if None, it will be computed in the EOB model
+        
+        # add the mapped ICs to the sub_meta dictionary
+        # and run
+        sub_meta.update(mapped_ids)
         try:
             pars        = CreateDict(**sub_meta)
             eob_wave    = Waveform_EOB(pars=pars)
             #eob_wave._u = eob_wave.u#-eob_wave.u[0]
         except Exception as e:
             # FIXME: no error msg is a little bit criminal
-            #print(f'Error occured in EOB wave generation:\n{e}')
+            # print(f'Error occured in EOB wave generation:\n{e}')
             eob_wave = None
         return eob_wave
     
-    def generate_opt_EOB(self, opt_data=None, verbose=None):
-        if verbose is  None: verbose  = self.verbose
-        if opt_data is None: opt_data = self.opt_data
-        if opt_data is None:
-            if verbose: print('Optimal ICs not found! Returning None')
-            opt_Waveform = None
-        else:
-            kx = self.ic_keys[0]
-            ky = self.ic_keys[1]
-            opt_Waveform = self.generate_EOB(ICs={kx:opt_data['x_opt'], 
-                                                  ky:opt_data['y_opt']})
-        return opt_Waveform
-
     def match_against_ref(self, eob_Waveform, verbose=None, iter_loop=False, return_matcher=False, cache={}):
         if verbose is None: verbose = self.verbose
         if eob_Waveform is not None:
@@ -388,56 +375,68 @@ class Optimizer(object):
         else:
             return mm
     
-    def __func_to_minimize(self, vxy, verbose=None, cache={}):
+    def __func_to_minimize(self, x, kys, verbose=None, cache={}):
         if verbose is None: verbose = self.verbose
-        kx = self.ic_keys[0]
-        ky = self.ic_keys[1]
-        eob_Waveform = self.generate_EOB(ICs={kx:vxy[0], ky:vxy[1]})
+        # reassemble the ICs
+        vs = {kys[i]: x[i] for i in range(len(kys))}
+        eob_Waveform = self.generate_EOB(ICs=vs)
         if eob_Waveform is not None:
             mm = self.match_against_ref(eob_Waveform, verbose=self.verbose, iter_loop=True, cache=cache)
         else:
             if self.kind_ic=='E0pph0':
-                pph0 = vxy[1]
+                pph0 = vs['pph0']
                 ref_meta = self.ref_Waveform.metadata
                 q    = ref_meta['q']
                 chi1 = ref_meta['chi1z']
                 chi2 = ref_meta['chi2z']
                 rvec = np.linspace(2,20,num=200)
                 Vmin = PotentialMinimum(rvec,pph0,q,chi1,chi2)
-                dV   = Vmin-vxy[0]
+                dV   = Vmin-vs['E0byM']
             else:
                 dV = 0
             mm = 1 + dV
         return mm
 
     def optimize_mismatch(self, use_ref_guess=True, verbose=None):
+        """
+        Optimize the mismatch between the reference waveform and the other model waveform.
+        """
         if verbose is None: verbose = self.verbose
-        kx = self.ic_keys[0]
-        ky = self.ic_keys[1]
-        vx_ref  = self.ref_Waveform.metadata[kx]
-        vy_ref  = self.ref_Waveform.metadata[ky]
+        kys     = self.opt_vars
+        bounds  = self.opt_bounds
 
-        bounds = self.opt_bounds
-        if vx_ref<bounds[0][0] and vx_ref>bounds[0][1]:
-            print('Warning! Reference value for {:s} is outside searching interval: [{:.2e},{:.2e}]'.format(ks,  bounds[0][0],  bounds[0][1]))
-        if vy_ref<bounds[1][0] and vy_ref>bounds[1][1]:
-            print('Warning! Reference value for {:s} is outside searching interval: [{:.2e},{:.2e}]'.format(ks,  bounds[1][0],  bounds[1][1]))
-        
+        # Treat variables which are in common with the reference
+        kys_ref = [ky for ky in kys if ky in self.ref_Waveform.metadata] # common keys
+        vs_ref  = {ky: self.ref_Waveform.metadata[ky] for ky in kys_ref} # reference values
+        for ky in kys:
+            vv = vs_ref[ky]
+            if vv<bounds[ky][0] or vv>bounds[ky][1]:
+                print('Warning! Reference value for {:s} is outside searching interval: [{:.2e},{:.2e}]'.format(ky,  bounds[ky][0],  bounds[ky][1]))
         if use_ref_guess:
-            vxy0 = np.array([vx_ref,vy_ref])
+            # use reference values whenever possible
+            vs0 = vs_ref
         else:
-            vx0  = random.uniform(bounds[0][0], bounds[0][1])
-            vy0  = random.uniform(bounds[1][0], bounds[1][1])
-            vxy0 = np.array([vx0, vy0])
+            # random initial guess
+            vs0 = {ky: np.random.uniform(bounds[ky][0], bounds[ky][1]) for ky in kys}
         
-        mm0, matcher0 = self.match_against_ref(self.generate_EOB(ICs={kx:vxy0[0], ky:vxy0[1]}),
-                                               iter_loop=False, return_matcher=True)
+        # randomly select the variables which are not in common with the reference
+        for ky in kys:
+            if ky not in kys_ref:
+                vs0[ky] = np.random.uniform(bounds[ky][0], bounds[ky][1])
+        
+        # reference match
+        mm0, matcher0 = self.match_against_ref(self.generate_EOB(ICs=vs0),
+                                                                iter_loop=False, 
+                                                                return_matcher=True
+                                              )
         if verbose:
             print(f'Original  mismatch    : {mm0:.3e}')
-            print( 'Optimization interval : {:5s} in [{:.2e}, {:.2e}]'.format(kx, bounds[0][0], bounds[0][1]))
-            print( '                      : {:5s} in [{:.2e}, {:.2e}]'.format(ky, bounds[1][0], bounds[1][1]))
-            print(f'Initial guess         : {kx:5s} : {vxy0[0]:.15f}')
-            print(f'                        {ky:5s} : {vxy0[1]:.15f}')
+            print( 'Optimization interval :')
+            for ky in kys:
+                print(f'                        {ky:5s} : [{bounds[ky][0]:.3e},{bounds[ky][1]:.3e}]')
+            print(f'Initial guess         :')
+            for ky in kys: 
+                print(f'                        {ky:5s} : {vs0[ky]:.15f}')
         
         if self.use_matcher_cache:
             if matcher0 is None:
@@ -447,53 +446,41 @@ class Optimizer(object):
                 cache = {'h1f':matcher0.h1f, 'M':matcher0.settings['M']}
         else:
             cache = {}
-
-        f = lambda vxy : self.__func_to_minimize(vxy, verbose=verbose, cache=cache)
+        
+        # prepare for annealing
+        x0           = [vs0[ky] for ky in kys]
+        bounds_array = np.array([[bounds[ky][0], bounds[ky][1]] for ky in kys])
+        f = lambda x : self.__func_to_minimize(x, kys, verbose=verbose, cache=cache)
 
         self.annealing_counter = 1
 
         t0_annealing = time.perf_counter()
-        opt_result = optimize.dual_annealing(f, maxfun=self.opt_maxfun, 
-                                                seed=self.opt_seed, x0=vxy0,
-                                                bounds=bounds)
+        opt_result   = optimize.dual_annealing(
+                                                f,
+                                                maxfun = self.opt_maxfun, 
+                                                seed   = self.opt_seed, 
+                                                x0     = x0,
+                                                bounds = bounds_array
+                                            )
+        
         opt_pars     = opt_result['x']
-        x_opt, y_opt = opt_pars[0], opt_pars[1]
-        mm_opt = opt_result['fun']
+        opts         = {kys[i]: opt_pars[i] for i in range(len(kys))}
+        mm_opt       = opt_result['fun']
         
         if verbose:
             print( '  >> mismatch - iter  : {:.3e} - {:3d}'.format(mm_opt, self.annealing_counter), end='\r')
             print(f'Optimized mismatch    : {mm_opt:.3e}')
-            print(f'Optimal ICs           : {kx:5s} : {x_opt:.15f}')
-            print(f'                        {ky:5s} : {y_opt:.15f}')
+            print(f'Optimal ICs           :' )
+            for ky in kys:
+                print(f'                        {ky:5s} : {opts[ky]:.15f}')
             print( 'Annealing time        : {:.1f} s'.format(time.perf_counter()-t0_annealing))
         
-        opt_eob = self.generate_opt_EOB(opt_data={'x_opt':x_opt, 'y_opt':y_opt})
-        if opt_eob is not None:
-            r0_eob = opt_eob.dyn['r'][0]
+        # generate the eob waveform corresponding to the optimal ICs
+        eob_opt = self.generate_EOB(ICs=opts)
+        if eob_opt is not None:
+            dyn0 = eob_opt.dyn
         else:
-            r0_eob = None
-
-        # fixing EOB IDs according to cut-option in matcher
-#        if opt_eob is not None and self.mm_settings['cut']:
-#            print(self.mm_settings)
-#            u_ref = self.ref_Waveform.u
-#            u_eob = opt_eob.u
-#            umrg_ref,_,_,_ = self.ref_Waveform.find_max()#-u_ref[0]
-#            umrg_eob,_,_,_ = opt_eob.find_max()#-u_eob[0]
-#            
-#            tmrg_ref,_,_,_ = self.ref_Waveform.find_max()-u_ref[0]
-#            tmrg_eob,_,_,_ = opt_eob.find_max()-u_eob[0]
-#            DeltaT = tmrg_eob-tmrg_ref
-#            import matplotlib.pyplot as plt # FIXME: only for debug, to remove
-#            plt.figure
-#            plt.plot(u_ref-umrg_ref, self.ref_Waveform.hlm[(2,2)]['real'], label='rn ref')
-#            plt.plot(u_eob-umrg_eob, opt_eob.hlm[(2,2)]['real'], label='eob')
-#            
-#            if DeltaT>0:
-#                opt_eob.cut(DeltaT)
-#                plt.plot(opt_eob.u-umrg_eob, opt_eob.hlm[(2,2)]['real'], label='eob', ls='--')
-#            plt.legend()
-#            plt.show()
+            dyn0 = None
 
         opt_data = { 
                     # store also some attributes, just for convenience 
@@ -515,19 +502,15 @@ class Optimizer(object):
                     'eps_initial'  : self.eps_initial,
                     'eps_factor'   : self.eps_factor,
                     # optimization results
-                    'kx'           : kx, 
-                    'ky'           : ky,
-                    'x_ref'        : vx_ref, 
-                    'y_ref'        : vy_ref,
                     'bounds'       : bounds, 
-                    'x0'           : vxy0[0], 
-                    'y0'           : vxy0[1], 
                     'mm0'          : mm0,
-                    'r0_eob'       : r0_eob,
-                    'x_opt'        : x_opt, 
-                    'y_opt'        : y_opt,
                     'mm_opt'       : mm_opt, 
                     }
+        for ky in kys:
+            opt_data[ky+'_opt'] = opts[ky]
+        if dyn0 is not None:
+            dyn0 = {ky: list(dyn0[ky]) for ky in dyn0.keys()}
+            opt_data['dyn0'] = dyn0
         
         return opt_data
 

--- a/PyART/utils/utils.py
+++ b/PyART/utils/utils.py
@@ -601,7 +601,7 @@ def print_dict_comparison(dict1_in,dict2_in,excluded_keys=[], dict1_name='dict1'
     for key, value1 in dict1.items():
         value2 = dict2[key]
         if isinstance(value1, dict):
-            dbool = ut.are_dictionaries_equal(value1, value2, verbose=True)
+            dbool = are_dictionaries_equal(value1, value2, verbose=True)
             if dbool:
                 print(f'>> issues with {key:16s} (dictionary)')
             else:

--- a/PyART/waveform.py
+++ b/PyART/waveform.py
@@ -133,7 +133,7 @@ class Waveform(object):
             raise RuntimeError('dothlm cannot be compute if hlm is not loaded')
         dothlm = {}
         for k in self.hlm:
-            hlm  = self.hlm[k]['h']
+            hlm  = self.hlm[k]['z']
             dhlm = ut.D1(hlm, self.u, 4)
             dhlm *= factor
             dothlm[k] = wf_ut.get_multipole_dict(dhlm)
@@ -144,7 +144,7 @@ class Waveform(object):
         for v in var:
             wave_dict = getattr(self, v)
             for lm in wave_dict:
-                h  = wave_dict[lm]['h']*factor
+                h  = wave_dict[lm]['z']*factor
                 wave_dict[lm] = wf_ut.get_multipole_dict(h)
         pass
 
@@ -224,7 +224,7 @@ class Waveform(object):
         new_u = np.arange(self.u[0], self.u[-1], dT)
         
         for k in self.hlm.keys():
-            h  = self.hlm[k]['h']
+            h  = self.hlm[k]['z']
             iA = np.interp(new_u, self.u, np.abs(h))
             ip = np.interp(new_u, self.u, -np.unwrap(np.angle(h)))
             ih = iA*np.exp(-1j*ip)
@@ -241,7 +241,7 @@ class Waveform(object):
             if warning: warnings.warn('Warning: dothlm not found, computing derivatives of hlm')
             for mode in modes:
                 self.dothlm[mode]      = {}
-                self.dothlm[mode]['h'] = ut.D02(self.t, self.hlm[mode]['h'])
+                self.dothlm[mode]['z'] = ut.D02(self.t, self.hlm[mode]['z'])
 
         dynamicsdict = waveform2energetics(
                         self.hlm, self.dothlm, self.t, modes,
@@ -303,7 +303,7 @@ class Waveform(object):
         t      = t_psi4
         for i, lm in enumerate(modes):
             l, m = lm
-            psi4 = self.psi4lm[lm]['h']
+            psi4 = self.psi4lm[lm]['z']
             mode = IntegrateMultipole(l, m, t, psi4, **integr_opts, 
                                       mass=M, radius=radius, 
                                       integrand='psi4')
@@ -362,36 +362,36 @@ def waveform2energetics(h, doth, t, modes, mnegative=False):
         fact = mnfactor[k] * oo16pi
         
         # Energy
-        dictdyn['dotE'][(l,m)] = fact * np.abs(doth[(l,m)]['h'])**2 
+        dictdyn['dotE'][(l,m)] = fact * np.abs(doth[(l,m)]['z'])**2 
 
         # Angular momentum
-        dictdyn['dotJz'][(l,m)] = fact * m * np.imag(h[(l,m)]['h'] * np.conj(doth[(l,m)]['h']))
+        dictdyn['dotJz'][(l,m)] = fact * m * np.imag(h[(l,m)]['z'] * np.conj(doth[(l,m)]['z']))
 
-        dothlm_1 = doth[(l,m-1)]['h'] if (l,m-1) in doth else 0*h[(l,m)]['h']
-        dothlm1  = doth[(l,m+1)]['h'] if (l,m+1) in doth else 0*h[(l,m)]['h']
+        dothlm_1 = doth[(l,m-1)]['z'] if (l,m-1) in doth else 0*h[(l,m)]['z']
+        dothlm1  = doth[(l,m+1)]['z'] if (l,m+1) in doth else 0*h[(l,m)]['z']
 
         dictdyn['dotJy'][(l,m)] = 0.5 * fact * \
-                                np.real( h[(l,m)]['h'] * (wf_ut.mc_f(l,m) * np.conj(dothlm1) - wf_ut.mc_f(l,-m) * np.conj(dothlm_1) ))
+                                np.real( h[(l,m)]['z'] * (wf_ut.mc_f(l,m) * np.conj(dothlm1) - wf_ut.mc_f(l,-m) * np.conj(dothlm_1) ))
         dictdyn['dotJx'][(l,m)] = 0.5 * fact * \
-                                np.real( h[(l,m)]['h'] * (wf_ut.mc_f(l,m) * np.conj(dothlm1) + wf_ut.mc_f(l,-m) * np.conj(dothlm_1) ))
+                                np.real( h[(l,m)]['z'] * (wf_ut.mc_f(l,m) * np.conj(dothlm1) + wf_ut.mc_f(l,-m) * np.conj(dothlm_1) ))
         dictdyn['dotJ'][(l,m)] = np.sqrt(dictdyn['dotJx'][(l,m)]**2 + 
                                          dictdyn['dotJy'][(l,m)]**2 + 
                                          dictdyn['dotJz'][(l,m)]**2
                                         )
 
         # Linear momentum
-        dothlm1   = doth[(l,m+1)]['h']   if (l,m+1)   in doth else 0*h[(l,m)]['h']
-        dothl_1m1 = doth[(l-1,m+1)]['h'] if (l-1,m+1) in doth else 0*h[(l,m)]['h']
-        dothl1m1  = doth[(l+1,m+1)]['h'] if (l+1,m+1) in doth else 0*h[(l,m)]['h']
-        dotl_1m   = doth[(l-1,m)]['h']   if (l-1,m)   in doth else 0*h[(l,m)]['h']
-        dothl1m   = doth[(l+1,m)]['h']   if (l+1,m)   in doth else 0*h[(l,m)]['h']
+        dothlm1   = doth[(l,m+1)]['z']   if (l,m+1)   in doth else 0*h[(l,m)]['z']
+        dothl_1m1 = doth[(l-1,m+1)]['z'] if (l-1,m+1) in doth else 0*h[(l,m)]['z']
+        dothl1m1  = doth[(l+1,m+1)]['z'] if (l+1,m+1) in doth else 0*h[(l,m)]['z']
+        dotl_1m   = doth[(l-1,m)]['z']   if (l-1,m)   in doth else 0*h[(l,m)]['z']
+        dothl1m   = doth[(l+1,m)]['z']   if (l+1,m)   in doth else 0*h[(l,m)]['z']
         
-        dotPxiy = 2.0 * fact * doth[(l,m)]['h'] * \
+        dotPxiy = 2.0 * fact * doth[(l,m)]['z'] * \
                 (wf_ut.mc_a(l,m) * np.conj(dothlm1) + wf_ut.mc_b(l,-m) * np.conj(dothl_1m1) - wf_ut.mc_b(l+1,m+1) * np.conj(dothl1m1))
         dictdyn['dotPy'][(l,m)] = np.imag(dotPxiy)
         dictdyn['dotPx'][(l,m)] = np.real(dotPxiy)
-        dictdyn['dotPz'][(l,m)] = fact * np.imag( doth[(l,m)]['h'] * \
-                                (wf_ut.mc_c(l,m) * np.conj(doth[(l,m)]['h']) + wf_ut.mc_d(l,m) * np.conj(dotl_1m) + wf_ut.mc_d(l+1,m) * np.conj(dothl1m)) )
+        dictdyn['dotPz'][(l,m)] = fact * np.imag( doth[(l,m)]['z'] * \
+                                (wf_ut.mc_c(l,m) * np.conj(doth[(l,m)]['z']) + wf_ut.mc_d(l,m) * np.conj(dotl_1m) + wf_ut.mc_d(l+1,m) * np.conj(dothl1m)) )
 
         dictdyn['dotP'][(l,m)] = np.sqrt(dictdyn['dotPx'][(l,m)]**2 + 
                                          dictdyn['dotPy'][(l,m)]**2 + 


### PR DESCRIPTION
Restructure the optimizer to work with generic number/kind of variables:
* `opt_bounds` is now a dictionary
* For convenience and backward compatibility we maintain the `kind_ic` option, which automatically sets the variables to optimize if the kind is known (`e0f0`, `E0pph0`);
* if `kind_ic` is set to `choose`, the user can freely select the variables (`vrs`) over which to perform the optimization. Note that these variables **do not need to directly be the EOB input vars**. However, they need to be linked to the EOB variables via a `map_function`, see e.g. [this line](https://github.com/RoxGamba/PyART/compare/mismatch...mismatch-restruct-opt?expand=1#diff-5c5c4387bc6b77076f294944b877c97fa8c35032e08b13c57602e405c089e323R206)

Additionally, we implement the possibility of performing the minimization with `dynesty` rather than with `dual_annealing`, and setup the structure needed for future generalizations.