### PR TITLE
fixing psi4-integration method in Waveform: now psi4 is updated after…

### DIFF
--- a/PyART/waveform.py
+++ b/PyART/waveform.py
@@ -305,6 +305,7 @@ class Waveform(object):
         """
         if modes is None:
             modes = self.psi4lm.keys()
+        psi4lm = {}
         dothlm = {}
         hlm    = {}
         t      = t_psi4
@@ -314,11 +315,13 @@ class Waveform(object):
             mode = IntegrateMultipole(l, m, t, psi4, **integr_opts, 
                                       mass=M, radius=radius, 
                                       integrand='psi4')
+            psi4lm[lm] = wf_ut.get_multipole_dict(mode.psi4)
             dothlm[lm] = wf_ut.get_multipole_dict(mode.dh)
             hlm[lm]    = wf_ut.get_multipole_dict(mode.h)
         self._u      = mode.u
         self._hlm    = hlm
         self._dothlm = dothlm
+        self._psi4lm = psi4lm
         return mode.integr_opts
 
 def waveform2energetics(h, doth, t, modes, mnegative=False):


### PR DESCRIPTION
… multipole integration, so that psi4 is consistent with extrapolation

# Description

Please include a summary of the changes and the related issue. 
Please also include relevant motivation and context. 
List any dependencies that are required for this change.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
