### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -4,6 +4,11 @@ name: docs_pages_workflow
 on:
   push:
     branches: [ main ]
+
+permissions:
+  contents: write
+  pages: write
+  id-token: write
  
 jobs:
  


### PR DESCRIPTION
Potential fix for [https://github.com/RoxGamba/PyART/security/code-scanning/1](https://github.com/RoxGamba/PyART/security/code-scanning/1)

Add an explicit `permissions` block in `.github/workflows/documentation.yml` so the workflow does not inherit potentially overbroad defaults. Since this workflow checks out code, builds docs, and deploys to `gh-pages`, the safest non-breaking fix is:

- `contents: write` (required for pushing to `gh-pages`)
- `pages: write` (commonly needed for Pages-related operations)
- `id-token: write` (often required by modern Pages flows; harmless if unused)

Place this block at the workflow root (after `on:` section and before `jobs:`) so it applies to all jobs unless overridden. This preserves existing behavior while making token privileges explicit.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
