### PR TITLE
Improve the multiplication/division by a factor; add tests

### DIFF
--- a/PyART/waveform.py
+++ b/PyART/waveform.py
@@ -239,6 +239,21 @@ class Waveform(object):
         else:
             return t_mrg, A_mrg, omg_mrg, domg_mrg
 
+    def _validate_uniform_u(self, quantity_name):
+        """
+        Validate the time grid used by finite-difference derivatives.
+        """
+
+        u = np.asarray(self.u)
+        if u.size < 6:
+            raise RuntimeError(
+                f"{quantity_name} requires at least 6 samples for 4th-order derivatives"
+            )
+
+        du = np.diff(u)
+        if not np.allclose(du, du[0], rtol=1e-10, atol=1e-14):
+            raise ValueError(f"{quantity_name} requires a uniformly sampled u-grid")
+
     def compute_dothlm(self, factor=1.0, only_warn=False):
         """
         Compute dothlm from self.hlm using
@@ -263,6 +278,9 @@ class Waveform(object):
                 logging.warning(msg)
             else:
                 raise RuntimeError(msg)
+
+        if self.hlm:
+            self._validate_uniform_u_for_derivatives("dothlm")
 
         dothlm = {}
         for k in self.hlm:
@@ -297,6 +315,9 @@ class Waveform(object):
                 logging.warning(msg)
             else:
                 raise RuntimeError(msg)
+
+        if self.dothlm:
+            self._validate_uniform_u_for_derivatives("psi4lm")
 
         psi4lm = {}
         for k in self.dothlm:
@@ -530,6 +551,7 @@ class Waveform(object):
             self._hp = ut.zero_pad_before(self.hp, dN, return_column=False)
             self._hc = ut.zero_pad_before(self.hp, dN, return_column=False)
             assert len(self.u) == len(self.hp)
+            assert len(self.u) == len(self.hc)
 
         self._f, self._hp = ut.fft(self.hp, dt)
         self._f, self._hc = ut.fft(self.hc, dt)

--- a/PyART/waveform.py
+++ b/PyART/waveform.py
@@ -122,7 +122,7 @@ class Waveform(object):
             new_wf._hc = self.hc / factor
         return new_wf
 
-    def __multiply_by__(self, var=["hlm"], factor=1.0):
+    def __multiply_by__(self, var=None, factor=1.0):
         """
         Multiply specified variable by factor
         Parameters
@@ -132,6 +132,8 @@ class Waveform(object):
         factor: float
             factor to multiply by
         """
+        if var is None:
+            var = ["hlm"]
         for v in var:
             wave_dict = getattr(self, v)
             for lm in wave_dict.keys():
@@ -139,7 +141,7 @@ class Waveform(object):
                 wave_dict[lm] = wf_ut.get_multipole_dict(h)
         pass
 
-    def __add_to__(self, var=["hlm"], factor=0.0):
+    def __add_to__(self, var=None, factor=0.0):
         """
         Add factor to specified variable
         Parameters
@@ -149,7 +151,8 @@ class Waveform(object):
         factor: float
             factor to add
         """
-
+        if var is None:
+            var = ["hlm"]
         for v in var:
             wave_dict = getattr(self, v)
             for lm in wave_dict.keys():

--- a/PyART/waveform.py
+++ b/PyART/waveform.py
@@ -90,19 +90,32 @@ class Waveform(object):
     # both methods return a new waveform object, without modifying the original one
     def __mul__(self, factor):
         # check if factor is a number
-        if not isinstance(factor, (int, float, complex)):
-            raise ValueError("Factor must be an int, float or complex number")
+        if not isinstance(factor, (int, float)):
+            raise ValueError("Factor must be an int or float number")
         new_wf = copy.deepcopy(self)
         new_wf.__multiply_by__(var=["hlm", "dothlm", "psi4lm"], factor=factor)
+
+        # also scale hp and hc if they are defined
+        if self.hp is not None:
+            new_wf._hp = self.hp * factor
+        if self.hc is not None:
+            new_wf._hc = self.hc * factor
+
         return new_wf
 
     def __truediv__(self, factor):
         # check if factor is a number
-        if not isinstance(factor, (int, float, complex)):
-            raise ValueError("Factor must be an int, float or complex number")
+        if not isinstance(factor, (int, float)):
+            raise ValueError("Factor must be an int or float number")
 
         new_wf = copy.deepcopy(self)
         new_wf.__multiply_by__(var=["hlm", "dothlm", "psi4lm"], factor=1 / factor)
+
+        # also scale hp and hc if they are defined
+        if self.hp is not None:
+            new_wf._hp = self.hp / factor
+        if self.hc is not None:
+            new_wf._hc = self.hc / factor
         return new_wf
 
     def __multiply_by__(self, var=["hlm"], factor=1.0):

--- a/PyART/waveform.py
+++ b/PyART/waveform.py
@@ -103,6 +103,9 @@ class Waveform(object):
 
         return new_wf
 
+    def __rmul__(self, factor):
+        return self.__mul__(factor)
+
     def __truediv__(self, factor):
         # check if factor is a number
         if not isinstance(factor, (int, float)):

--- a/PyART/waveform.py
+++ b/PyART/waveform.py
@@ -287,7 +287,7 @@ class Waveform(object):
                 raise RuntimeError(msg)
 
         if self.hlm:
-            self._validate_uniform_u_for_derivatives("dothlm")
+            self._validate_uniform_u("dothlm")
 
         dothlm = {}
         for k in self.hlm:
@@ -324,7 +324,7 @@ class Waveform(object):
                 raise RuntimeError(msg)
 
         if self.dothlm:
-            self._validate_uniform_u_for_derivatives("psi4lm")
+            self._validate_uniform_u("psi4lm")
 
         psi4lm = {}
         for k in self.dothlm:

--- a/PyART/waveform.py
+++ b/PyART/waveform.py
@@ -5,6 +5,7 @@ Classes to handle waveforms
 # standard imports
 import logging
 import numpy as np
+import copy
 from scipy.signal import find_peaks
 from scipy import integrate
 import matplotlib.pyplot as plt
@@ -84,6 +85,60 @@ class Waveform(object):
     @property
     def kind(self):
         return self._kind
+
+    # define multiplication and division by a factor
+    # both methods return a new waveform object, without modifying the original one
+    def __mul__(self, factor):
+        # check if factor is a number
+        if not isinstance(factor, (int, float, complex)):
+            raise ValueError("Factor must be an int, float or complex number")
+        new_wf = copy.deepcopy(self)
+        new_wf.__multiply_by__(var=["hlm", "dothlm", "psi4lm"], factor=factor)
+        return new_wf
+
+    def __truediv__(self, factor):
+        # check if factor is a number
+        if not isinstance(factor, (int, float, complex)):
+            raise ValueError("Factor must be an int, float or complex number")
+
+        new_wf = copy.deepcopy(self)
+        new_wf.__multiply_by__(var=["hlm", "dothlm", "psi4lm"], factor=1 / factor)
+        return new_wf
+
+    def __multiply_by__(self, var=["hlm"], factor=1.0):
+        """
+        Multiply specified variable by factor
+        Parameters
+        ----------
+        var: list
+            list of variables to multiply, e.g. ['hlm', 'dothlm']
+        factor: float
+            factor to multiply by
+        """
+        for v in var:
+            wave_dict = getattr(self, v)
+            for lm in wave_dict.keys():
+                h = wave_dict[lm]["z"] * factor
+                wave_dict[lm] = wf_ut.get_multipole_dict(h)
+        pass
+
+    def __add_to__(self, var=["hlm"], factor=0.0):
+        """
+        Add factor to specified variable
+        Parameters
+        ----------
+        var: list
+            list of variables to add to, e.g. ['hlm', 'dothlm']
+        factor: float
+            factor to add
+        """
+
+        for v in var:
+            wave_dict = getattr(self, v)
+            for lm in wave_dict.keys():
+                h = wave_dict[lm]["z"] + factor
+                wave_dict[lm] = wf_ut.get_multipole_dict(h)
+        pass
 
     def find_max(
         self,
@@ -237,24 +292,6 @@ class Waveform(object):
             ddothlm *= factor
             psi4lm[k] = wf_ut.get_multipole_dict(ddothlm)
         self._psi4lm = psi4lm
-        pass
-
-    def multiply_by(self, var=["hlm"], factor=1.0):
-        """
-        Multiply specified variable by factor
-        Parameters
-        ----------
-        var: list
-            list of variables to multiply, e.g. ['hlm', 'dothlm']
-        factor: float
-            factor to multiply by
-        """
-
-        for v in var:
-            wave_dict = getattr(self, v)
-            for lm in wave_dict:
-                h = wave_dict[lm]["z"] * factor
-                wave_dict[lm] = wf_ut.get_multipole_dict(h)
         pass
 
     def cut(
@@ -485,6 +522,15 @@ class Waveform(object):
         self._f, self._hc = ut.fft(self.hc, dt)
         self._domain = "Frequency"
         pass
+
+    def to_time(self):
+        """
+        Inverse Fourier transform the waveform from frequency to time domain
+        Returns
+        -------
+        out: (t, hp, hc)
+        """
+        raise NotImplementedError(".to_time method not implemented yet")
 
     def integrate_data(
         self,

--- a/PyART/waveform.py
+++ b/PyART/waveform.py
@@ -4,6 +4,7 @@ Classes to handle waveforms
 
 # standard imports
 import logging
+import numbers
 import numpy as np
 import copy
 from scipy.signal import find_peaks
@@ -90,8 +91,8 @@ class Waveform(object):
     # both methods return a new waveform object, without modifying the original one
     def __mul__(self, factor):
         # check if factor is a number
-        if not isinstance(factor, (int, float)):
-            raise ValueError("Factor must be an int or float number")
+        if not isinstance(factor, numbers.Real):
+            return NotImplemented
         new_wf = copy.deepcopy(self)
         new_wf.__multiply_by__(var=["hlm", "dothlm", "psi4lm"], factor=factor)
 
@@ -108,8 +109,8 @@ class Waveform(object):
 
     def __truediv__(self, factor):
         # check if factor is a number
-        if not isinstance(factor, (int, float)):
-            raise ValueError("Factor must be an int or float number")
+        if not isinstance(factor, numbers.Real):
+            return NotImplemented
 
         new_wf = copy.deepcopy(self)
         new_wf.__multiply_by__(var=["hlm", "dothlm", "psi4lm"], factor=1 / factor)

--- a/PyART/waveform.py
+++ b/PyART/waveform.py
@@ -574,6 +574,19 @@ class Waveform(object):
         """
         raise NotImplementedError(".to_time method not implemented yet")
 
+    def phase_shift(self, delta_phi, var="hlm"):
+        """
+        Phase shift var by delta_phi.
+        The shift is propagated as:
+        var -> var * exp(-1j * m * delta_phi)
+        """
+        wave_dict = getattr(self, var)
+        for lm in wave_dict.keys():
+            emm = lm[1]
+            h = wave_dict[lm]["z"] * np.exp(-1j * emm * delta_phi)
+            wave_dict[lm] = wf_ut.get_multipole_dict(h)
+        pass
+
     def integrate_data(
         self,
         t_psi4,

--- a/docs/source/tutorials/intro_to_waveforms.ipynb
+++ b/docs/source/tutorials/intro_to_waveforms.ipynb
@@ -91,7 +91,7 @@
       "- find_max\n",
       "- integrate_data\n",
       "- interpolate_hlm\n",
-      "- multiply_by\n",
+      "- __mul__ / __rmul__ / __truediv__\n",
       "- to_frequency\n"
      ]
     }

--- a/docs/source/tutorials/nr_eob_mismatch.ipynb
+++ b/docs/source/tutorials/nr_eob_mismatch.ipynb
@@ -203,7 +203,7 @@
     "}\n",
     "\n",
     "eob = teob.Waveform_EOB(pars=eobpars)\n",
-    "eob.multiply_by(var=['hlm'], factor=q/(1+q)**2)\n",
+    "eob = eob * (q/(1+q)**2)\n",
     "\n",
     "print(\"EOB waveform generated successfully\")"
    ]

--- a/examples/match_sxs.py
+++ b/examples/match_sxs.py
@@ -101,7 +101,7 @@ eobpars = {
     "spin_interp_domain": 0,
 }
 eob = teob.Waveform_EOB(pars=eobpars)
-eob.multiply_by(var=["hlm"], factor=q / (1 + q) ** 2)
+eob = eob * (q / (1 + q) ** 2)
 
 # plt.figure
 # plt.plot(eob.u, eob.hlm[(2,2)]['A'])

--- a/tests/test_waveform.py
+++ b/tests/test_waveform.py
@@ -3,12 +3,13 @@ General tests for the waveform class in PyART
 """
 
 from PyART import waveform
+from PyART.utils import wf_utils
 import copy
 import numpy as np
 import pytest
 
 
-def test_waveform():
+def test_waveform_attributes_and_mul():
 
     # Create a mock waveform
     wf = waveform.Waveform()
@@ -18,19 +19,21 @@ def test_waveform():
         assert hasattr(wf, attr), f"Waveform object does not have attribute {attr}"
 
     # fill the waveform with some mock data
-    re = np.array([1, 2, 3])
-    im = np.array([4, 5, 6])
+    u = np.linspace(0.0, 10.0, 20)
+    z = np.exp(-1j * 0.2 * u) * (1.0 + 0.2 * np.sin(u))
+    re = z.real
+    im = z.imag
     h_dict = {
-        "z": re + 1j * im,
-        "A": np.sqrt(re**2 + im**2),
-        "p": np.arctan2(im, re),
+        "z": z,
+        "A": np.abs(z),
+        "p": -np.unwrap(np.angle(z)),
         "real": re,
         "imag": im,
     }
     wf._hlm[(2, 2)] = h_dict
     wf._psi4lm[(2, 2)] = copy.deepcopy(h_dict)
     wf._dothlm[(2, 2)] = copy.deepcopy(h_dict)
-    wf._u = np.array([0, 1, 2])
+    wf._u = u.copy()
 
     # check that multiplication and division by a factor works
     original_modes = {
@@ -68,3 +71,100 @@ def test_waveform():
     with pytest.raises(TypeError):
         wf * "2"
     pass
+
+
+def test_find_max_variants_and_errors():
+
+    # mock waveform
+    wf = waveform.Waveform()
+    wf._u = np.arange(6, dtype=float)
+    amp = np.array([0.0, 1.0, 0.0, 2.0, 0.0, 0.5])
+    phase = np.linspace(0.0, 1.0, len(amp))
+    wf._hlm[(2, 2)] = wf_utils.get_multipole_dict(amp * np.exp(-1j * phase))
+    wf._psi4lm[(2, 2)] = wf_utils.get_multipole_dict(amp * np.exp(-1j * phase))
+
+    # test identification of max
+    t_mrg, A_mrg, _, _, idx = wf.find_max(kind="last-peak", return_idx=True)
+    assert idx == 3
+    assert t_mrg == pytest.approx(3.0)
+    assert A_mrg == pytest.approx(2.0)
+
+    t_mrg_g, A_mrg_g, _, _ = wf.find_max(kind="global")
+    assert t_mrg_g == pytest.approx(3.0)
+    assert A_mrg_g == pytest.approx(2.0)
+
+    t_after, _, _, _, idx_after = wf.find_max(
+        kind="first-max-after-t", umin=2.0, return_idx=True
+    )
+    assert idx_after == 3
+    assert t_after == pytest.approx(3.0)
+
+    with pytest.raises(ValueError):
+        wf.find_max(kind="not-a-valid-option")
+
+    # repeat also for psi4lm
+    wf._t_psi4 = wf.u.copy()
+    t_mrg_psi4, _, _, _ = wf.find_max(wave="psi4lm", kind="global")
+    assert t_mrg_psi4 == pytest.approx(3.0)
+
+
+def test_compute_dothlm_and_psi4lm():
+
+    # mock waveform
+    wf = waveform.Waveform()
+    u = np.linspace(0.0, 5.0, 64)
+    amp = 1.7
+    omega = 1.3
+    z = amp * np.sin(omega * u)
+    wf._u = u
+    wf._hlm[(2, 2)] = wf_utils.get_multipole_dict(z)
+
+    wf.compute_dothlm(factor=2.0)
+    assert (2, 2) in wf.dothlm
+    assert len(wf.dothlm[(2, 2)]["z"]) == len(u)
+
+    # d/dt[A sin(omega t)] = A omega cos(omega t), then scaled by factor=2.
+    expected_doth = 2.0 * amp * omega * np.cos(omega * u)
+    interior = slice(5, -5)
+    assert np.allclose(
+        wf.dothlm[(2, 2)]["z"][interior].real,
+        expected_doth[interior],
+        rtol=1e-4,
+        atol=1e-4,
+    )
+    assert np.allclose(wf.dothlm[(2, 2)]["z"][interior].imag, 0.0, atol=1e-10)
+
+    wf.compute_psi4lm(factor=0.5)
+    assert (2, 2) in wf.psi4lm
+    assert len(wf.psi4lm[(2, 2)]["z"]) == len(u)
+
+    # d/dt[doth] = -2 A omega^2 sin(omega t), then scaled by factor=0.5.
+    expected_psi4 = -amp * omega * omega * np.sin(omega * u)
+    assert np.allclose(
+        wf.psi4lm[(2, 2)]["z"][interior].real,
+        expected_psi4[interior],
+        rtol=2e-4,
+        atol=2e-4,
+    )
+    assert np.allclose(wf.psi4lm[(2, 2)]["z"][interior].imag, 0.0, atol=1e-10)
+
+    empty = waveform.Waveform()
+    with pytest.raises(RuntimeError):
+        empty.compute_dothlm()
+    with pytest.raises(RuntimeError):
+        empty.compute_psi4lm()
+
+    # only_warn=True should not raise
+    empty.compute_dothlm(only_warn=True)
+    empty.compute_psi4lm(only_warn=True)
+
+    non_uniform = waveform.Waveform()
+    non_uniform._u = np.array([0.0, 0.1, 0.21, 0.33, 0.46, 0.6, 0.75])
+    z_nu = np.sin(non_uniform.u)
+    non_uniform._hlm[(2, 2)] = wf_utils.get_multipole_dict(z_nu)
+    with pytest.raises(ValueError, match="uniformly sampled u-grid"):
+        non_uniform.compute_dothlm()
+
+    non_uniform._dothlm[(2, 2)] = wf_utils.get_multipole_dict(z_nu)
+    with pytest.raises(ValueError, match="uniformly sampled u-grid"):
+        non_uniform.compute_psi4lm()

--- a/tests/test_waveform.py
+++ b/tests/test_waveform.py
@@ -186,8 +186,6 @@ def test_waveform_phase_shift():
         omega * u + 0.5 * 2
     )  # since the mode is (2, 2), the phase shift is 2 times the input value
 
-    print(expected_phase, wf.hlm[(2, 2)]["p"])
-
     interior = slice(5, -5)
     assert np.allclose(
         wf.hlm[(2, 2)]["p"][interior], expected_phase[interior], rtol=1e-4, atol=1e-4

--- a/tests/test_waveform.py
+++ b/tests/test_waveform.py
@@ -3,7 +3,7 @@ General tests for the waveform class in PyART
 """
 
 from PyART import waveform
-
+import copy
 import numpy as np
 
 
@@ -16,7 +16,27 @@ def test_waveform():
     for attr in ["hlm", "u", "t", "f", "hp", "hc", "dothlm", "psi4lm", "dyn", "kind"]:
         assert hasattr(wf, attr), f"Waveform object does not have attribute {attr}"
 
-    # check methods
-    # ...
+    # fill the waveform with some mock data
+    re = np.array([1, 2, 3])
+    im = np.array([4, 5, 6])
+    h_dict = {
+        "z": re + 1j * im,
+        "A": np.sqrt(re**2 + im**2),
+        "p": np.arctan2(im, re),
+        "real": re,
+        "imag": im,
+    }
+    wf._hlm[(2, 2)] = h_dict
+    wf._psi4lm[(2, 2)] = copy.deepcopy(h_dict)
+    wf._dothlm[(2, 2)] = copy.deepcopy(h_dict)
+    wf._u = np.array([0, 1, 2])
 
+    # check that multiplication and division by a factor works
+    wf2 = wf * 2
+    for var in ["hlm", "dothlm", "psi4lm"]:
+        assert np.all(wf2.__getattribute__(var)[(2, 2)]["real"] == 2 * re)
+
+    wfo2 = wf / 2
+    for var in ["hlm", "dothlm", "psi4lm"]:
+        assert np.all(wfo2.__getattribute__(var)[(2, 2)]["real"] == 0.5 * re)
     pass

--- a/tests/test_waveform.py
+++ b/tests/test_waveform.py
@@ -46,8 +46,12 @@ def test_waveform():
         assert np.all(wf3.__getattribute__(var)[(2, 2)]["real"] == 2 * re)
 
     for var in ["hlm", "dothlm", "psi4lm"]:
-        assert np.all(wf.__getattribute__(var)[(2, 2)]["real"] == original_modes[var]["real"])
-        assert np.all(wf.__getattribute__(var)[(2, 2)]["imag"] == original_modes[var]["imag"])
+        assert np.all(
+            wf.__getattribute__(var)[(2, 2)]["real"] == original_modes[var]["real"]
+        )
+        assert np.all(
+            wf.__getattribute__(var)[(2, 2)]["imag"] == original_modes[var]["imag"]
+        )
         assert np.all(wf.__getattribute__(var)[(2, 2)]["z"] == original_modes[var]["z"])
         assert np.all(wf.__getattribute__(var)[(2, 2)]["A"] == original_modes[var]["A"])
         assert np.all(wf.__getattribute__(var)[(2, 2)]["p"] == original_modes[var]["p"])

--- a/tests/test_waveform.py
+++ b/tests/test_waveform.py
@@ -5,6 +5,7 @@ General tests for the waveform class in PyART
 from PyART import waveform
 import copy
 import numpy as np
+import pytest
 
 
 def test_waveform():
@@ -45,6 +46,10 @@ def test_waveform():
     for var in ["hlm", "dothlm", "psi4lm"]:
         assert np.all(wf3.__getattribute__(var)[(2, 2)]["real"] == 2 * re)
 
+    wf4 = wf * np.int64(2)
+    for var in ["hlm", "dothlm", "psi4lm"]:
+        assert np.all(wf4.__getattribute__(var)[(2, 2)]["real"] == 2 * re)
+
     for var in ["hlm", "dothlm", "psi4lm"]:
         assert np.all(
             wf.__getattribute__(var)[(2, 2)]["real"] == original_modes[var]["real"]
@@ -59,4 +64,7 @@ def test_waveform():
     wfo2 = wf / 2
     for var in ["hlm", "dothlm", "psi4lm"]:
         assert np.all(wfo2.__getattribute__(var)[(2, 2)]["real"] == 0.5 * re)
+
+    with pytest.raises(TypeError):
+        wf * "2"
     pass

--- a/tests/test_waveform.py
+++ b/tests/test_waveform.py
@@ -168,3 +168,28 @@ def test_compute_dothlm_and_psi4lm():
     non_uniform._dothlm[(2, 2)] = wf_utils.get_multipole_dict(z_nu)
     with pytest.raises(ValueError, match="uniformly sampled u-grid"):
         non_uniform.compute_psi4lm()
+
+
+def test_waveform_phase_shift():
+
+    # mock waveform
+    wf = waveform.Waveform()
+    u = np.linspace(0.0, 5.0, 64)
+    amp = 1.7
+    omega = 1.3
+    z = amp * np.exp(-1j * omega * u)
+    wf._u = u
+    wf._hlm[(2, 2)] = wf_utils.get_multipole_dict(z)
+
+    wf.phase_shift(0.5, var="hlm")
+    expected_phase = (
+        omega * u + 0.5 * 2
+    )  # since the mode is (2, 2), the phase shift is 2 times the input value
+
+    print(expected_phase, wf.hlm[(2, 2)]["p"])
+
+    interior = slice(5, -5)
+    assert np.allclose(
+        wf.hlm[(2, 2)]["p"][interior], expected_phase[interior], rtol=1e-4, atol=1e-4
+    )
+    assert np.allclose(wf.hlm[(2, 2)]["A"][interior], amp, rtol=1e-4, atol=1e-4)

--- a/tests/test_waveform.py
+++ b/tests/test_waveform.py
@@ -32,9 +32,25 @@ def test_waveform():
     wf._u = np.array([0, 1, 2])
 
     # check that multiplication and division by a factor works
+    original_modes = {
+        var: copy.deepcopy(wf.__getattribute__(var)[(2, 2)])
+        for var in ["hlm", "dothlm", "psi4lm"]
+    }
+
     wf2 = wf * 2
     for var in ["hlm", "dothlm", "psi4lm"]:
         assert np.all(wf2.__getattribute__(var)[(2, 2)]["real"] == 2 * re)
+
+    wf3 = 2 * wf
+    for var in ["hlm", "dothlm", "psi4lm"]:
+        assert np.all(wf3.__getattribute__(var)[(2, 2)]["real"] == 2 * re)
+
+    for var in ["hlm", "dothlm", "psi4lm"]:
+        assert np.all(wf.__getattribute__(var)[(2, 2)]["real"] == original_modes[var]["real"])
+        assert np.all(wf.__getattribute__(var)[(2, 2)]["imag"] == original_modes[var]["imag"])
+        assert np.all(wf.__getattribute__(var)[(2, 2)]["z"] == original_modes[var]["z"])
+        assert np.all(wf.__getattribute__(var)[(2, 2)]["A"] == original_modes[var]["A"])
+        assert np.all(wf.__getattribute__(var)[(2, 2)]["p"] == original_modes[var]["p"])
 
     wfo2 = wf / 2
     for var in ["hlm", "dothlm", "psi4lm"]:


### PR DESCRIPTION
# Description
Add the `__mul__` and `__truediv__` methods to `Waveform`, relying on the (fixed) `__multiply_by__` method. This allows us to do things like:
```python
wf2 = 2 * wf
```
where `wf` is a waveform object. Note that we return a **new** object, to avoid silently modifying the internal properties of the original one. 

Fixes #74 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
