### PR TITLE
Select N3 extrapolation for v3 SXS catalog

### DIFF
--- a/PyART/catalogs/sxs.py
+++ b/PyART/catalogs/sxs.py
@@ -290,6 +290,7 @@ class Waveform_SXS(Waveform):
         sxs_sim = sxsmod.load(
             name_level,
             extrapolation_order=extrapolation_order,
+            extrapolation=f"N{extrapolation_order}",
             ignore_deprecation=ignore_deprecation,
             progress=True,
         )


### PR DESCRIPTION
The v3.0 SXS catalog keys extrapolation off the 'extrapolation="N3"' argument; passing only extrapolation_order falls back to N2. This adds the N{order} string so the requested order is honoured.