### PR TITLE
Add gls to pipeline

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -26,6 +26,11 @@ jobs:
         with:
           python-version: 3.11
  
+      - name: Install GSL (required to build teobresums/pyseobnr)
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libgsl-dev
+
       - name: Install dependencies
         run: |
           pip install -r requirements.txt -r requirements-docs.txt -r requirements-catalogs.txt -r requirements-models.txt

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -23,6 +23,10 @@ jobs:
       uses: actions/setup-python@v3
       with:
         python-version: "3.12"
+    - name: Install GSL (required to build teobresums/pyseobnr)
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y libgsl-dev
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/README.md
+++ b/README.md
@@ -45,6 +45,14 @@ Extras can be combined, e.g.:
 pip install ".[catalogs,models]"
 ```
 
+> **Note:** the `models` extra compiles C/Cython extensions (`teobresums`, and `pyseobnr`
+> via `pygsl_lite`) linked against the GNU Scientific Library. Install the GSL headers with
+> your system package manager *before* installing this extra:
+> ```
+> apt-get install libgsl-dev   # Debian/Ubuntu
+> brew install gsl             # macOS
+> ```
+
 > **Note:** PyART depends on `pycbc`, which currently has two incompatibilities with numpy 2.x.
 > After installing, apply the one-time patch:
 > ```

--- a/requirements-models.txt
+++ b/requirements-models.txt
@@ -1,6 +1,14 @@
 # Extra dependencies for optional analytical/semi-analytical waveform models.
 # Each model is imported inside try/except, so the base install works without
 # this extra -- only code that explicitly uses these models needs it.
+#
+# System prerequisite: teobresums and pyseobnr (via pygsl_lite) compile C/Cython
+# extensions linked against the GNU Scientific Library. Install the GSL headers
+# with your system package manager before installing this extra, e.g.:
+#   apt-get install libgsl-dev   (Debian/Ubuntu)
+#   brew install gsl             (macOS)
+# There is no installable "gsl" package on PyPI -- the name is taken by an
+# unrelated project -- so this cannot be expressed as a line in this file.
 
 # TEOBResumS from Dali branch; setup.py is in the Python/ subdirectory
 teobresums @ git+https://bitbucket.org/teobresums/teobresums.git@Dali#subdirectory=Python
@@ -9,7 +17,7 @@ teobresums @ git+https://bitbucket.org/teobresums/teobresums.git@Dali#subdirecto
 phenomxpy @ git+https://gitlab.com/imrphenom-dev/phenomxpy.git
 
 # SEOBNR (Spinning Effective One-Body) approximants
-# pyseobnr
+pyseobnr
 
 # Other optional models (commented; uncomment to use)
 # gw-eccentricity>=1.0.4

--- a/requirements-models.txt
+++ b/requirements-models.txt
@@ -9,7 +9,7 @@ teobresums @ git+https://bitbucket.org/teobresums/teobresums.git@Dali#subdirecto
 phenomxpy @ git+https://gitlab.com/imrphenom-dev/phenomxpy.git
 
 # SEOBNR (Spinning Effective One-Body) approximants
-pyseobnr
+# pyseobnr
 
 # Other optional models (commented; uncomment to use)
 # gw-eccentricity>=1.0.4


### PR DESCRIPTION
The pipeline is currently failing because of `pyseobnr` & teobresums dependencies . 
Adding gsl to it fixes the issue.
This should be noted as well in the README of the repository.
