### PR TITLE
Bilby nr source model

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -180,3 +180,6 @@ results/
 /RIT_BBH_*/
 /ICCUB-*/
 /PNPedia/
+
+# Data downloaded by the example scripts (NR simulations, figures)
+examples/local_data/

--- a/PyART/analysis/match.py
+++ b/PyART/analysis/match.py
@@ -35,35 +35,6 @@ from pycbc.psd import aLIGOZeroDetHighPower, sensitivity_curve_lisa_semi_analyti
 from pycbc.psd.read import from_txt
 
 
-def _copy_for_matching(waveform):
-    """
-    Return a copy of a waveform safe to mutate inside the Matcher.
-
-    The Matcher conditions its inputs in place -- it can cut them, shift their
-    time array, and rewrite ``hlm`` during pre-alignment -- and computing a
-    mismatch must not modify the caller's objects. A full ``deepcopy`` is not
-    used because catalog waveforms hold non-copyable state (open h5py handles,
-    an ``sxs.Coalescence`` object, ...). Instead the object is shallow-copied,
-    which shares that state harmlessly, and only the wave-data containers that
-    the conditioning mutates are duplicated:
-
-    - the mode dictionaries (``_hlm``/``_dothlm``/``_psi4lm``), whose inner
-      arrays are cut in place by ``Waveform.cut``;
-    - the time and polarization arrays, which are reassigned.
-
-    This is robust for any ``Waveform`` subclass regardless of what else it
-    carries.
-    """
-    wf = copy.copy(waveform)
-    for attr in ("_hlm", "_dothlm", "_psi4lm"):
-        wf.__dict__[attr] = copy.deepcopy(getattr(waveform, attr))
-    for attr in ("_u", "_t", "_t_psi4", "_hp", "_hc"):
-        val = getattr(waveform, attr, None)
-        if val is not None:
-            wf.__dict__[attr] = np.array(val, copy=True)
-    return wf
-
-
 @dataclass
 class _LocalWaveform:
     """
@@ -162,8 +133,8 @@ class Matcher(object):
         # Work on copies: the conditioning below (cut, pre-align, compute_hphc)
         # mutates the waveform objects, and computing a mismatch must not modify
         # the caller's inputs.
-        WaveForm1 = _copy_for_matching(WaveForm1)
-        WaveForm2 = _copy_for_matching(WaveForm2)
+        WaveForm1 = WaveForm1.copy()
+        WaveForm2 = WaveForm2.copy()
 
         # Choose the appropriate mismatch function
         if self.settings["kind"] == "single-mode":

--- a/PyART/plugin/__init__.py
+++ b/PyART/plugin/__init__.py
@@ -1,0 +1,9 @@
+"""
+Plugins that expose PyART waveforms to external inference libraries.
+
+Nothing is imported eagerly here: ``bilby_plugin`` pulls in lal, lalsimulation
+and bilby, which are not required to use the rest of PyART. Import it
+explicitly instead:
+
+    from PyART.plugin.bilby_plugin import nr_frequency_domain_source_model
+"""

--- a/PyART/plugin/__init__.py
+++ b/PyART/plugin/__init__.py
@@ -1,9 +1,9 @@
 """
 Plugins that expose PyART waveforms to external inference libraries.
 
-Nothing is imported eagerly here: ``bilby_plugin`` pulls in lal, lalsimulation
-and bilby, which are not required to use the rest of PyART. Import it
-explicitly instead:
+Nothing is imported eagerly here: these modules exist to be used with an
+external library, and the rest of PyART should not pay their import cost.
+Import the one you want explicitly instead:
 
     from PyART.plugin.bilby_plugin import nr_frequency_domain_source_model
 """

--- a/PyART/plugin/bilby_plugin.py
+++ b/PyART/plugin/bilby_plugin.py
@@ -1,5 +1,9 @@
 """
 Bilby frequency-domain source models backed by PyART's NR catalogues.
+
+The physics lives in the Waveform class and in PyART.utils.wf_utils; what is
+here is catalogue loading, caching, and the bilby calling convention.
+
 Usage:
     import bilby
     from PyART.plugin.bilby_plugin import nr_frequency_domain_source_model
@@ -18,276 +22,13 @@ Usage:
 """
 
 import logging
-import numpy
-from itertools import product
-from scipy.interpolate import CubicSpline
 
-try:
-    import lal
-    import lalsimulation
-except ImportError:
-    raise ImportError("WARNING: LALSimulation and/or LAL not installed.")
+import numpy as np
+
+from ..utils import utils as ut
+from ..utils import wf_utils as wf_ut
 
 logger = logging.getLogger(__name__)
-
-
-# ─────────────────────────────────────────────────────────────────────────────
-# Shared conditioning-parameter computation
-# ─────────────────────────────────────────────────────────────────────────────
-
-
-def compute_conditioning_parameters(binary_parameters):
-    """
-    This conditoning scheme is to closely approximate SimInspiralFD-style. Much of it is ~~copied~~ inspired by
-    https://github.com/AEI-ACR/pyseobnr/blob/70e730002061210264dcc297d01e6b4c8c5a0bc1/pyseobnr/generate_waveform.py#L1258
-
-    Returns
-    -------
-    f_start : float
-        Lower starting frequency for the TD waveform call (includes extra time).
-    f_lower : float
-        Effective minimum frequency used for the chirp-time bound; equal to
-        ``min(minimum_frequency, ISCO_9M)`` following the SimInspiralFD convention.
-    fico : float
-        Schwarzschild ISCO frequency used for Stage 2.
-    chirp_time : float
-        Chirp time at ``f_lower``.
-    extra_time : float
-        Extra time (extra_cycles / f_lower) prepended before the waveform.
-    extra_time_fraction : float
-        Fraction of ``chirp_time`` used for the Stage-1 taper (0.1).
-    """
-    extra_time_fraction = 0.1
-    extra_cycles = 3.0
-    mass1 = binary_parameters["mass1"]
-    mass2 = binary_parameters["mass2"]
-    spin1z = binary_parameters["spin1z"]
-    spin2z = binary_parameters["spin2z"]
-    minimum_frequency = binary_parameters["f_lower"]
-
-    # SimInspiralFD uses r = 9M ISCO to decide whether to lower f_min.
-    fico_check = 1.0 / (pow(9.0, 1.5) * numpy.pi * (mass1 + mass2) * lal.MTSUN_SI)
-    f_lower = min(minimum_frequency, fico_check)
-
-    # Schwarzschild (r = 6M) ISCO for Stage 2.
-    fico = 1.0 / (pow(6.0, 1.5) * numpy.pi * (mass1 + mass2) * lal.MTSUN_SI)
-
-    # chirp time
-    chirp_time = lalsimulation.SimInspiralChirpTimeBound(
-        f_lower, mass1 * lal.MSUN_SI, mass2 * lal.MSUN_SI, spin1z, spin2z
-    )
-
-    spinkerr = lalsimulation.SimInspiralFinalBlackHoleSpinBound(spin1z, spin2z)
-    tmerge = lalsimulation.SimInspiralMergeTimeBound(
-        mass1 * lal.MSUN_SI, mass2 * lal.MSUN_SI
-    ) + lalsimulation.SimInspiralRingdownTimeBound(
-        (mass1 + mass2) * lal.MSUN_SI, spinkerr
-    )
-
-    extra_time = extra_cycles / f_lower
-    f_start = lalsimulation.SimInspiralChirpStartFrequencyBound(
-        (1.0 + extra_time_fraction) * chirp_time + tmerge + extra_time,
-        mass1 * lal.MSUN_SI,
-        mass2 * lal.MSUN_SI,
-    )
-
-    return f_start, f_lower, fico, chirp_time, extra_time, extra_time_fraction
-
-
-def get_frequency_domain_polarisations(
-    hp_ts, hc_ts, sampling_frequency, delta_f, maximum_frequency=None
-):
-    """
-    Resize conditioned TD polarisations to a power-of-2 chirp length and
-    FFT with LAL's REAL8TimeFreqFFT.
-
-    Again inspired by this: https://github.com/AEI-ACR/pyseobnr/blob/70e730002061210264dcc297d01e6b4c8c5a0bc1/pyseobnr/generate_waveform.py#L1333
-
-    Returns
-    -------
-    frequency_array : ndarray  -- one-sided frequencies [0 .. Nyquist].
-    hptilde : frequency domain h+(f) as LAL COMPLEX16FrequencySeries (one-sided, up to Nyquist).
-    hctilde : frequency domain hx(f) as LAL COMPLEX16FrequencySeries (one-sided, up to Nyquist).
-    """
-    nyquist = sampling_frequency // 2
-    if maximum_frequency is None:
-        maximum_frequency = nyquist
-
-    if delta_f != 0:
-        n = int(numpy.round(maximum_frequency / delta_f))
-        if n & (n - 1):
-            exp = numpy.frexp(n)
-            nyquist = numpy.ldexp(1, int(exp[1])) * delta_f
-
-    delta_t = 0.5 / nyquist
-
-    if delta_f == 0:
-        chirp_length = hp_ts.data.length
-        exp = numpy.frexp(chirp_length)
-        chirp_length = int(numpy.ldexp(1, int(exp[1])))
-        delta_f = 1.0 / (chirp_length * delta_t)
-    else:
-        chirp_length = int(1.0 / (delta_f * delta_t))
-
-    # Keep the last chirp_length samples (i.e. keep the merger / ringdown).
-    # When the NR waveform is shorter than the segment the first argument is
-    # negative and LAL prepends zeros, which is what we want.
-    lal.ResizeREAL8TimeSeries(hp_ts, hp_ts.data.length - chirp_length, chirp_length)
-    lal.ResizeREAL8TimeSeries(hc_ts, hc_ts.data.length - chirp_length, chirp_length)
-
-    hptilde = lal.CreateCOMPLEX16FrequencySeries(
-        "FD H_PLUS",
-        hp_ts.epoch,
-        0.0,
-        delta_f,
-        lal.DimensionlessUnit,
-        int(chirp_length / 2 + 1),
-    )
-
-    hctilde = lal.CreateCOMPLEX16FrequencySeries(
-        "FD H_CROSS",
-        hc_ts.epoch,
-        0.0,
-        delta_f,
-        lal.DimensionlessUnit,
-        int(chirp_length / 2 + 1),
-    )
-
-    plan = lal.CreateForwardREAL8FFTPlan(chirp_length, 0)
-    lal.REAL8TimeFreqFFT(hptilde, hp_ts, plan)
-    lal.REAL8TimeFreqFFT(hctilde, hc_ts, plan)
-
-    frequency_array = numpy.arange(len(hptilde.data.data)) * hptilde.deltaF
-    return frequency_array, hptilde, hctilde
-
-
-# ─────────────────────────────────────────────────────────────────────────────
-# NR-specific helpers
-# ─────────────────────────────────────────────────────────────────────────────
-
-
-def default_mode_array(ellmax, load_m0=False):
-    """
-    The (l, m) list that PyART's catalog loaders build, repeated here so the
-    caller can ask for a subset without reaching into them.
-    """
-    return [
-        (l, m)
-        for l, m in product(range(2, ellmax + 1), range(-ellmax, ellmax + 1))
-        if (m != 0 or load_m0) and l >= numpy.abs(m)
-    ]
-
-
-def invariant_amplitude(hlm, mode_array):
-    """
-    sqrt(sum_lm |h_lm|^2): the frame-invariant amplitude, whose peak is what LAL
-    call t = 0.
-    """
-    amplitude = 0.0
-    for mode in mode_array:
-        amplitude = amplitude + numpy.abs(hlm[tuple(mode)]["A"]) ** 2
-    return numpy.sqrt(amplitude)
-
-
-def estimate_time_of_maximum_amplitude(time_array, hlm, mode_array, precision=1e-3):
-    """
-    identical to what is done in pyseobnr
-    """
-    invariant_amp = invariant_amplitude(hlm, mode_array)
-    assert len(invariant_amp) == len(time_array)
-    amplitude_interpolator = CubicSpline(time_array, invariant_amp)
-
-    index_of_peak_amplitude = int(numpy.argmax(invariant_amp))
-    coarse_peak_time = time_array[index_of_peak_amplitude]
-
-    # local spacing: the grid need not be uniform (SXS output is adaptive)
-    i = min(index_of_peak_amplitude, len(time_array) - 2)
-    delta_t = time_array[i + 1] - time_array[i]
-
-    step = min(precision, delta_t / 10.0)
-    fine_peak_time = numpy.arange(
-        coarse_peak_time - delta_t, coarse_peak_time + delta_t, step
-    )
-    amplitude_fine = amplitude_interpolator(fine_peak_time)
-    return float(fine_peak_time[numpy.argmax(amplitude_fine)])
-
-
-def trim_nr_junk_and_drift(u, hlm, mode_array, peak_u, t_final=None, t_after_peak=None):
-    """
-    Drop the tail of the NR record.
-
-    GRAthena++ ringdowns drift at late times.
-    Two ways to cut it, both in geometric units (M):
-
-    t_final      : absolute cut in the catalogue's own retarded time u.
-    t_after_peak : cut this many M after the invariant-amplitude peak. Anchored
-                   to the merger rather than to the end of the file, so it
-                   survives a change of cut_U or resolution.
-
-    If both are given, the earlier of the two wins!
-
-    Returns
-    -------
-    u, hlm : the trimmed time array and mode dict (a new dict; the input, which
-             is owned by the cached Waveform object, is not modified).
-    """
-    keep = numpy.ones(len(u), dtype=bool)
-    if t_final is not None:
-        keep &= u <= t_final
-    if t_after_peak is not None:
-        keep &= u <= peak_u + t_after_peak
-
-    if keep.all():
-        return u, hlm
-
-    if not keep.any():
-        raise RuntimeError(
-            f"t_final={t_final} / t_after_peak={t_after_peak} removed the whole "
-            f"waveform (u spans [{u[0]:.1f}, {u[-1]:.1f}], peak at {peak_u:.1f})"
-        )
-
-    logger.debug(
-        "trimming NR data at u <= %.1f M (was %.1f M): %d of %d samples kept",
-        u[keep][-1],
-        u[-1],
-        keep.sum(),
-        len(u),
-    )
-    trimmed = {
-        tuple(mode): {k: v[keep] for k, v in hlm[tuple(mode)].items()}
-        for mode in mode_array
-    }
-    return u[keep], trimmed
-
-
-def compute_polarisations_from_modes(hlm, mode_array, iota, phase):
-    signal = 0.0 + 0.0j
-    for mode in mode_array:
-        ell, emm = int(mode[0]), int(mode[1])
-        ylm = lal.SpinWeightedSphericalHarmonic(
-            iota, numpy.pi / 2 - phase, -2, ell, emm
-        )
-        signal = signal + ylm * hlm[(ell, emm)]
-    return numpy.real(signal), -numpy.imag(signal)
-
-
-def interpolate_modes(u, hlm, mode_array, new_u):
-    """
-    Returns a plain {(l, m): complex ndarray} dict.
-    """
-    from scipy.interpolate import CubicSpline
-
-    out = {}
-    for mode in mode_array:
-        key = tuple(mode)
-        # Adopted Cubic spline rather than what PyART does here:
-        # https://github.com/RoxGamba/PyART/blob/05bb78ff58b73f0a2480fdbcbc010d0cf71d950f/PyART/waveform.py#L502
-        # amplitude = numpy.interp(new_u, u, hlm[key]["A"])
-        # phase = numpy.interp(new_u, u, hlm[key]["p"])
-        amplitude = CubicSpline(u, hlm[key]["A"])(new_u)
-        phase = CubicSpline(u, hlm[key]["p"])(new_u)
-        out[key] = amplitude * numpy.exp(-1j * phase)
-    return out
 
 
 # ─────────────────────────────────────────────────────────────────────────────
@@ -304,6 +45,9 @@ _DEFAULT_T_AFTER_PEAK = {"sxs": None, "gra": 100.0}
 def load_nr_waveform(**waveform_arguments):
     """
     Return a PyART Waveform for the requested simulation, loading it at most once.
+
+    The returned object is the cached one and is shared by every caller, so it
+    must not be modified: use ``Waveform.copy()`` before doing anything in place.
     """
     catalog = str(waveform_arguments["catalog"]).lower()
     ID = waveform_arguments["ID"]
@@ -319,89 +63,109 @@ def load_nr_waveform(**waveform_arguments):
         order = waveform_arguments.get("order", 2)
         level = waveform_arguments.get("level", None)
         key = ("sxs", ID, path, ellmax, cut_U, load_m0, order, level)
+
+        def load():
+            from ..catalogs import sxs as sxs_catalog
+
+            return sxs_catalog.Waveform_SXS(
+                path=path,
+                ID=ID,
+                order=order,
+                level=level,
+                ellmax=ellmax,
+                cut_U=cut_U,
+                load_m0=load_m0,
+                download=download,
+                nu_rescale=False,
+                load=["hlm", "metadata"],
+                ignore_deprecation=waveform_arguments.get("ignore_deprecation", True),
+            )
+
     elif catalog == "gra":
         ext = waveform_arguments.get("ext", "ext")
         res = waveform_arguments.get("res", "128")
         r_ext = waveform_arguments.get("r_ext", None)
         key = ("gra", ID, path, ellmax, cut_U, load_m0, ext, res, r_ext)
+
+        def load():
+            from ..catalogs import gra as gra_catalog
+
+            return gra_catalog.Waveform_GRA(
+                ID=ID,
+                path=path,
+                ellmax=ellmax,
+                ext=ext,
+                res=res,
+                r_ext=r_ext,
+                cut_U=cut_U,
+                download=download,
+                nu_rescale=False,
+            )
+
     else:
         raise NotImplementedError(
-            f"Not implemented '{catalog}'. "
-            f"Ask someone to add support for catalog '{catalog}' or force Koustav to do it"
+            f"catalog '{catalog}' is not implemented; supported: 'sxs', 'gra'"
         )
 
-    if key in _WAVEFORM_CACHE:
-        return _WAVEFORM_CACHE[key]
-
-    logger.info("loading %s simulation %s from %s", catalog.upper(), ID, path)
-    if catalog.lower() == "sxs":
-        from ..catalogs import sxs as sxs_catalog
-
-        waveform = sxs_catalog.Waveform_SXS(
-            path=path,
-            ID=ID,
-            order=order,
-            level=level,
-            ellmax=ellmax,
-            cut_U=cut_U,
-            load_m0=load_m0,
-            download=download,
-            nu_rescale=False,
-            load=["hlm", "metadata"],
-            ignore_deprecation=waveform_arguments.get("ignore_deprecation", True),
-        )
-    elif catalog.lower() == "gra":
-        from ..catalogs import gra as gra_catalog
-
-        waveform = gra_catalog.Waveform_GRA(
-            ID=ID,
-            path=path,
-            ellmax=ellmax,
-            ext=ext,
-            res=res,
-            r_ext=r_ext,
-            cut_U=cut_U,
-            download=download,
-            nu_rescale=False,
-        )
-    else:
-        raise ValueError(
-            f'Ask someone to add support for catalog "{catalog}" '
-            f"or force Koustav to do it"
-        )
-
-    _WAVEFORM_CACHE[key] = waveform
-    return waveform
+    if key not in _WAVEFORM_CACHE:
+        logger.info("loading %s simulation %s from %s", catalog.upper(), ID, path)
+        _WAVEFORM_CACHE[key] = load()
+    return _WAVEFORM_CACHE[key]
 
 
 def clear_waveform_cache():
-    """Drop every memoised simulation. Mostly useful in tests."""
+    """
+    Drop every memoised simulation.
+
+    The cache is unbounded and each entry holds the full mode data, so this is
+    worth calling between runs over many simulations. It is also what the tests
+    use to make each case independent.
+    """
     _WAVEFORM_CACHE.clear()
 
 
 def component_masses_and_spins(metadata, total_mass):
     """
-    Who is fatter?
+    Component masses and spins in LAL's mass ordering (mass_1 >= mass_2).
+
+    NR metadata labels the two bodies however the simulation did; LAL requires
+    the heavier one to be body 1. Exchanging the labels flips the x axis, so it
+    is not enough to swap: the in-plane spin components are swapped *and*
+    negated, while the z components are swapped as they are. Together these
+    amount to a rigid rotation of the system by pi about z, which the caller
+    undoes by flipping the sign of the odd-m modes (see
+    nr_time_domain_polarisations).
+
+    Ported from PrecessingNRSur_switch_labels_if_needed in LALSimulation:
+    https://github.com/lscsoft/lalsuite/blob/8b202b25185d553f268c64312095da72539614b0/lalsimulation/lib/LALSimIMRPrecessingNRSur.c#L2059
+
+    Parameters
+    ----------
+    metadata: dict
+        PyART metadata, providing m1, m2 and chi{1,2}{x,y,z}
+    total_mass: float
+        total mass of the binary in Solar masses
+
+    Returns
+    -------
+    out: (mass_1, mass_2, spin_1, spin_2, labels_switched)
+        masses in Solar masses, spins as (x, y, z) dimensionless vectors, and
+        whether the two bodies were relabelled
     """
     m1, m2 = float(metadata["m1"]), float(metadata["m2"])
     mass_1 = total_mass * m1 / (m1 + m2)
     mass_2 = total_mass * m2 / (m1 + m2)
-    spin_1x, spin_1y, spin_1z = (
-        float(metadata["chi1x"]),
-        float(metadata["chi1y"]),
-        float(metadata["chi1z"]),
-    )
-    spin_2x, spin_2y, spin_2z = (
-        float(metadata["chi2x"]),
-        float(metadata["chi2y"]),
-        float(metadata["chi2z"]),
-    )
-    if mass_1 < mass_2:
+    spin_1 = np.array([float(metadata[f"chi1{c}"]) for c in "xyz"])
+    spin_2 = np.array([float(metadata[f"chi2{c}"]) for c in "xyz"])
+
+    labels_switched = mass_1 < mass_2
+    if labels_switched:
         mass_1, mass_2 = mass_2, mass_1
-        spin_1x, spin_2x = spin_2x, spin_1x
-        spin_1y, spin_2y = spin_2y, spin_1y
-        spin_1z, spin_2z = spin_2z, spin_1z
-    return mass_1, mass_2, spin_1z, spin_2z
+        # in-plane components: swap and negate; z component: swap only
+        flip = np.array([-1.0, -1.0, 1.0])
+        spin_1, spin_2 = spin_2 * flip, spin_1 * flip
+
+    return mass_1, mass_2, spin_1, spin_2, labels_switched
 
 
 def resolve_mode_array(waveform, waveform_arguments):
@@ -440,41 +204,64 @@ def nr_time_domain_polarisations(
         Dimensionless strain at ``luminosity_distance``.
     """
     sampling_frequency = waveform_arguments["sampling_frequency"]
-
-    waveform = load_nr_waveform(**waveform_arguments)
     catalog = str(waveform_arguments["catalog"]).lower()
+
+    # The cached Waveform is shared, and everything below works in place.
+    waveform = load_nr_waveform(**waveform_arguments).copy()
     mode_array = resolve_mode_array(waveform, waveform_arguments)
+    *_, labels_switched = component_masses_and_spins(waveform.metadata, total_mass)
 
-    geometric_to_seconds = total_mass * lal.MTSUN_SI
-    distance_in_metres = luminosity_distance * 1e6 * lal.PC_SI
+    # t = 0 goes on the peak of the frame-invariant amplitude, which is where
+    # LAL puts it.
+    peak_u = waveform.find_max(
+        kind="argmax", modes=mode_array, refine=True, wave="hlm"
+    )[0]
 
-    u = numpy.asarray(waveform.u)
-    # Centre t = 0 on the peak of the invariant amplitude, which is where LAL
-    # put it, then drop the late-time tail if requested.
-    peak_u = estimate_time_of_maximum_amplitude(u, waveform.hlm, mode_array)
+    # Drop the tail of the record if asked: GRAthena++ ringdowns drift at late
+    # times. t_final is an absolute cut in the catalogue's own retarded time u,
+    # t_after_peak is anchored to the merger instead, so it survives a change of
+    # cut_U or resolution. If both are given, the earlier one wins.
     t_after_peak = waveform_arguments.get(
-        "t_after_peak", _DEFAULT_T_AFTER_PEAK[catalog]
+        "t_after_peak", _DEFAULT_T_AFTER_PEAK.get(catalog)
     )
-    u, hlm = trim_nr_junk_and_drift(
-        u,
-        waveform.hlm,
-        mode_array,
-        peak_u,
-        t_final=waveform_arguments.get("t_final", None),
-        t_after_peak=t_after_peak,
-    )
+    t_final = waveform_arguments.get("t_final", None)
+    bounds = [
+        bound
+        for bound in (t_final, None if t_after_peak is None else peak_u + t_after_peak)
+        if bound is not None
+    ]
+    if bounds:
+        u_max = min(bounds)
+        if u_max < waveform.u[-1]:
+            logger.debug(
+                "trimming NR data at u <= %.1f M (was %.1f M)", u_max, waveform.u[-1]
+            )
+            waveform.cut(waveform.u[-1] - u_max, from_the_end=True, cut_dothlm=True)
 
-    times = (u - peak_u) * geometric_to_seconds
+    peak_t = peak_u * total_mass * ut.consts["Msun"]
+    waveform.to_SI(total_mass, luminosity_distance)
 
     delta_t = 1.0 / sampling_frequency
-    time = numpy.arange(times[0], times[-1], delta_t)
-    hlm_interpolated = interpolate_modes(times, hlm, mode_array, time)
-
-    hplus, hcross = compute_polarisations_from_modes(
-        hlm_interpolated, mode_array, iota, phase
+    time = np.arange(waveform.u[0] - peak_t, waveform.u[-1] - peak_t, delta_t)
+    _, hlm = waveform.interpolate_hlm(
+        new_u=time + peak_t, kind="cubic", modes=mode_array
     )
-    amplitude_scale = geometric_to_seconds * lal.C_SI / distance_in_metres
-    return time, hplus * amplitude_scale, hcross * amplitude_scale
+
+    if labels_switched:
+        # Relabelling the bodies rotated the system by pi about z. Undo it by
+        # flipping the odd-m modes; the even-m ones are insensitive to it.
+        # LALSimIMRPrecessingNRSur.c:2283
+        hlm = {
+            (ell, emm): wf_ut.get_multipole_dict(((-1) ** emm) * mode["z"])
+            for (ell, emm), mode in hlm.items()
+        }
+
+    # assume_symmetry=False: the NR catalogues load the m<0 modes independently
+    # rather than deriving them, and the simulation need not be non-precessing.
+    hplus, hcross = wf_ut.compute_hphc(
+        hlm, phi=phase, i=iota, modes=mode_array, assume_symmetry=False
+    )
+    return time, hplus, hcross
 
 
 def nr_frequency_domain_source_model(
@@ -523,69 +310,38 @@ def nr_frequency_domain_source_model(
     delta_f = frequency_array[1] - frequency_array[0]
 
     waveform = load_nr_waveform(**waveform_arguments)
-    mass_1, mass_2, spin_1z, spin_2z = component_masses_and_spins(
+    mass_1, mass_2, spin_1, spin_2, _ = component_masses_and_spins(
         waveform.metadata, total_mass
     )
 
-    binary_parameters = {
-        "mass1": mass_1,
-        "mass2": mass_2,
-        "spin1z": spin_1z,
-        "spin2z": spin_2z,
-        "f_lower": minimum_frequency,
-    }
-    _, _, fico, chirp_time, extra_time, extra_time_fraction = (
-        compute_conditioning_parameters(binary_parameters)
+    _, _, f_isco, chirp_time, extra_time, extra_time_fraction = (
+        wf_ut.compute_conditioning_parameters(
+            mass_1, mass_2, spin_1[2], spin_2[2], minimum_frequency
+        )
     )
 
     time, hplus, hcross = nr_time_domain_polarisations(
         total_mass, luminosity_distance, iota, phase, **waveform_arguments
     )
-    delta_t = 1.0 / sampling_frequency
-    lal_epoch = lal.LIGOTimeGPS(float(time[0]))
-
-    # SimInspiralFD generates from a frequency low enough that the taper below
-    # has somewhere to act. An NR record is however long it is, and if it is
-    # shorter than the taper, SimInspiralTDConditionStage1 aborts the process
-    # rather than returning an error -- so check here, where we can still say
-    # something useful.
-    taper_length = extra_time_fraction * chirp_time + extra_time
-    record_length = float(time[-1] - time[0])
-    if record_length <= taper_length:
-        raise ValueError(
-            f"the NR record is {record_length:.3f} s long at M = {total_mass:.1f} "
-            f"Msun, but the SimInspiralFD conditioning wants to taper "
-            f"{taper_length:.3f} s of it at minimum_frequency = "
-            f"{minimum_frequency:.1f} Hz. Raise the total mass, raise "
-            f"minimum_frequency, or use a longer simulation."
-        )
 
     # Same treatment before Fourier transforming as SimInspiralFD applies.
-    # Stage-1: taper the initial extra segment before f_min, high-pass at f_min
-    # and remove zero-padding. Stage-2: taper one cycle at f_min from the start
-    # and one at f_ISCO from the end, to kill the filter transients.
-    # https://github.com/lscsoft/lalsuite/blob/06047f8491f5cf480c720b47e2ad7bf85b26adc4/lalsimulation/lib/LALSimInspiral.c#L5504
-    time_length = len(hplus)
-    hp_ts = lal.CreateREAL8TimeSeries(
-        "hplus", lal_epoch, 0, delta_t, lal.DimensionlessUnit, time_length
+    hp_ts, hc_ts = wf_ut.condition_td_polarisations(
+        hplus,
+        hcross,
+        1.0 / sampling_frequency,
+        float(time[0]),
+        minimum_frequency,
+        chirp_time,
+        extra_time,
+        f_isco,
+        extra_time_fraction=extra_time_fraction,
     )
-    hc_ts = lal.CreateREAL8TimeSeries(
-        "hcross", lal_epoch, 0, delta_t, lal.DimensionlessUnit, time_length
-    )
-    hp_ts.data.data[:] = hplus
-    hc_ts.data.data[:] = hcross
-
-    lalsimulation.SimInspiralTDConditionStage1(
-        hp_ts, hc_ts, extra_time_fraction * chirp_time + extra_time, minimum_frequency
-    )
-    lalsimulation.SimInspiralTDConditionStage2(hp_ts, hc_ts, minimum_frequency, fico)
-
-    _, hptilde, hctilde = get_frequency_domain_polarisations(
+    _, hptilde, hctilde = wf_ut.fd_polarisations_from_td(
         hp_ts, hc_ts, sampling_frequency, delta_f, maximum_frequency=maximum_frequency
     )
 
-    hplus_output = numpy.zeros_like(frequency_array, dtype=complex)
-    hcross_output = numpy.zeros_like(frequency_array, dtype=complex)
+    hplus_output = np.zeros_like(frequency_array, dtype=complex)
+    hcross_output = np.zeros_like(frequency_array, dtype=complex)
     n = len(frequency_array)
     if len(hptilde.data.data) > n:
         hplus_output = hptilde.data.data[:n].copy()
@@ -607,7 +363,7 @@ def nr_frequency_domain_source_model(
         + hptilde.epoch.gpsSeconds
         + hptilde.epoch.gpsNanoSeconds * 1e-9
     )
-    time_shift = numpy.exp(-2j * numpy.pi * frequency_array[frequency_bounds] * dt)
+    time_shift = np.exp(-2j * np.pi * frequency_array[frequency_bounds] * dt)
     hplus_output[frequency_bounds] *= time_shift
     hcross_output[frequency_bounds] *= time_shift
 
@@ -622,15 +378,23 @@ def sxs_frequency_domain_source_model(
     phase,
     **waveform_arguments,
 ):
-    """:func:`nr_frequency_domain_source_model` pinned to the SXS catalogue."""
-    waveform_arguments["catalog"] = "sxs"
+    """
+    :func:`nr_frequency_domain_source_model` pinned to the SXS catalogue.
+
+    Written out as a plain ``def`` rather than a ``functools.partial`` because
+    bilby resolves ``frequency-domain-source-model`` by dotted name from an ini
+    file and then introspects the signature to work out which sampled
+    parameters to pass; a partial object does not expose one. Having an entry
+    point per catalogue also means an ini file cannot typo the ``catalog``
+    waveform-argument, since it does not have to supply it.
+    """
     return nr_frequency_domain_source_model(
         frequency_array,
         total_mass,
         luminosity_distance,
         iota,
         phase,
-        **waveform_arguments,
+        **{**waveform_arguments, "catalog": "sxs"},
     )
 
 
@@ -642,13 +406,17 @@ def gra_frequency_domain_source_model(
     phase,
     **waveform_arguments,
 ):
-    """:func:`nr_frequency_domain_source_model` pinned to the GRAthena++ catalogue."""
-    waveform_arguments["catalog"] = "gra"
+    """
+    :func:`nr_frequency_domain_source_model` pinned to the GRAthena++ catalogue.
+
+    See :func:`sxs_frequency_domain_source_model` for why this is a plain
+    function rather than a partial.
+    """
     return nr_frequency_domain_source_model(
         frequency_array,
         total_mass,
         luminosity_distance,
         iota,
         phase,
-        **waveform_arguments,
+        **{**waveform_arguments, "catalog": "gra"},
     )

--- a/PyART/plugin/bilby_plugin.py
+++ b/PyART/plugin/bilby_plugin.py
@@ -264,7 +264,9 @@ def compute_polarisations_from_modes(hlm, mode_array, iota, phase):
     signal = 0.0 + 0.0j
     for mode in mode_array:
         ell, emm = int(mode[0]), int(mode[1])
-        ylm = lal.SpinWeightedSphericalHarmonic(iota, numpy.pi/2 - phase, -2, ell, emm)
+        ylm = lal.SpinWeightedSphericalHarmonic(
+            iota, numpy.pi / 2 - phase, -2, ell, emm
+        )
         signal = signal + ylm * hlm[(ell, emm)]
     return numpy.real(signal), -numpy.imag(signal)
 
@@ -384,11 +386,13 @@ def component_masses_and_spins(metadata, total_mass):
     m1, m2 = float(metadata["m1"]), float(metadata["m2"])
     mass_1 = total_mass * m1 / (m1 + m2)
     mass_2 = total_mass * m2 / (m1 + m2)
-    spin_1x, spin_1y, spin_1z = (float(metadata["chi1x"]),
+    spin_1x, spin_1y, spin_1z = (
+        float(metadata["chi1x"]),
         float(metadata["chi1y"]),
         float(metadata["chi1z"]),
     )
-    spin_2x, spin_2y, spin_2z = (float(metadata["chi2x"]),
+    spin_2x, spin_2y, spin_2z = (
+        float(metadata["chi2x"]),
         float(metadata["chi2y"]),
         float(metadata["chi2z"]),
     )

--- a/PyART/plugin/bilby_plugin.py
+++ b/PyART/plugin/bilby_plugin.py
@@ -1,0 +1,666 @@
+"""
+Bilby frequency-domain source models backed by PyART's NR catalogues.
+Usage:
+    import bilby
+    from PyART.plugin.bilby_plugin import nr_frequency_domain_source_model
+
+    waveform_arguments = dict(
+        catalog="sxs", ID="0305", path="./local_data/sxs/", download=True,
+        ellmax=4, cut_U=200,
+        minimum_frequency=20.0, maximum_frequency=1024.0,
+        sampling_frequency=4096.0,
+    )
+    generator = bilby.gw.WaveformGenerator(
+        duration=4.0, sampling_frequency=4096.0,
+        frequency_domain_source_model=nr_frequency_domain_source_model,
+        waveform_arguments=waveform_arguments,
+    )
+"""
+
+import logging
+import numpy
+from itertools import product
+from scipy.interpolate import CubicSpline
+
+try:
+    import lal
+    import lalsimulation
+except ImportError:
+    raise ImportError("WARNING: LALSimulation and/or LAL not installed.")
+
+logger = logging.getLogger(__name__)
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Shared conditioning-parameter computation
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def compute_conditioning_parameters(binary_parameters):
+    """
+    This conditoning scheme is to closely approximate SimInspiralFD-style. Much of it is ~~copied~~ inspired by
+    https://github.com/AEI-ACR/pyseobnr/blob/70e730002061210264dcc297d01e6b4c8c5a0bc1/pyseobnr/generate_waveform.py#L1258
+
+    Returns
+    -------
+    f_start : float
+        Lower starting frequency for the TD waveform call (includes extra time).
+    f_lower : float
+        Effective minimum frequency used for the chirp-time bound; equal to
+        ``min(minimum_frequency, ISCO_9M)`` following the SimInspiralFD convention.
+    fico : float
+        Schwarzschild ISCO frequency used for Stage 2.
+    chirp_time : float
+        Chirp time at ``f_lower``.
+    extra_time : float
+        Extra time (extra_cycles / f_lower) prepended before the waveform.
+    extra_time_fraction : float
+        Fraction of ``chirp_time`` used for the Stage-1 taper (0.1).
+    """
+    extra_time_fraction = 0.1
+    extra_cycles = 3.0
+    mass1 = binary_parameters["mass1"]
+    mass2 = binary_parameters["mass2"]
+    spin1z = binary_parameters["spin1z"]
+    spin2z = binary_parameters["spin2z"]
+    minimum_frequency = binary_parameters["f_lower"]
+
+    # SimInspiralFD uses r = 9M ISCO to decide whether to lower f_min.
+    fico_check = 1.0 / (pow(9.0, 1.5) * numpy.pi * (mass1 + mass2) * lal.MTSUN_SI)
+    f_lower = min(minimum_frequency, fico_check)
+
+    # Schwarzschild (r = 6M) ISCO for Stage 2.
+    fico = 1.0 / (pow(6.0, 1.5) * numpy.pi * (mass1 + mass2) * lal.MTSUN_SI)
+
+    # chirp time
+    chirp_time = lalsimulation.SimInspiralChirpTimeBound(
+        f_lower, mass1 * lal.MSUN_SI, mass2 * lal.MSUN_SI, spin1z, spin2z
+    )
+
+    spinkerr = lalsimulation.SimInspiralFinalBlackHoleSpinBound(spin1z, spin2z)
+    tmerge = lalsimulation.SimInspiralMergeTimeBound(
+        mass1 * lal.MSUN_SI, mass2 * lal.MSUN_SI
+    ) + lalsimulation.SimInspiralRingdownTimeBound(
+        (mass1 + mass2) * lal.MSUN_SI, spinkerr
+    )
+
+    extra_time = extra_cycles / f_lower
+    f_start = lalsimulation.SimInspiralChirpStartFrequencyBound(
+        (1.0 + extra_time_fraction) * chirp_time + tmerge + extra_time,
+        mass1 * lal.MSUN_SI,
+        mass2 * lal.MSUN_SI,
+    )
+
+    return f_start, f_lower, fico, chirp_time, extra_time, extra_time_fraction
+
+
+def get_frequency_domain_polarisations(
+    hp_ts, hc_ts, sampling_frequency, delta_f, maximum_frequency=None
+):
+    """
+    Resize conditioned TD polarisations to a power-of-2 chirp length and
+    FFT with LAL's REAL8TimeFreqFFT.
+
+    Again inspired by this: https://github.com/AEI-ACR/pyseobnr/blob/70e730002061210264dcc297d01e6b4c8c5a0bc1/pyseobnr/generate_waveform.py#L1333
+
+    Returns
+    -------
+    frequency_array : ndarray  -- one-sided frequencies [0 .. Nyquist].
+    hptilde : frequency domain h+(f) as LAL COMPLEX16FrequencySeries (one-sided, up to Nyquist).
+    hctilde : frequency domain hx(f) as LAL COMPLEX16FrequencySeries (one-sided, up to Nyquist).
+    """
+    nyquist = sampling_frequency // 2
+    if maximum_frequency is None:
+        maximum_frequency = nyquist
+
+    if delta_f != 0:
+        n = int(numpy.round(maximum_frequency / delta_f))
+        if n & (n - 1):
+            exp = numpy.frexp(n)
+            nyquist = numpy.ldexp(1, int(exp[1])) * delta_f
+
+    delta_t = 0.5 / nyquist
+
+    if delta_f == 0:
+        chirp_length = hp_ts.data.length
+        exp = numpy.frexp(chirp_length)
+        chirp_length = int(numpy.ldexp(1, int(exp[1])))
+        delta_f = 1.0 / (chirp_length * delta_t)
+    else:
+        chirp_length = int(1.0 / (delta_f * delta_t))
+
+    # Keep the last chirp_length samples (i.e. keep the merger / ringdown).
+    # When the NR waveform is shorter than the segment the first argument is
+    # negative and LAL prepends zeros, which is what we want.
+    lal.ResizeREAL8TimeSeries(hp_ts, hp_ts.data.length - chirp_length, chirp_length)
+    lal.ResizeREAL8TimeSeries(hc_ts, hc_ts.data.length - chirp_length, chirp_length)
+
+    hptilde = lal.CreateCOMPLEX16FrequencySeries(
+        "FD H_PLUS",
+        hp_ts.epoch,
+        0.0,
+        delta_f,
+        lal.DimensionlessUnit,
+        int(chirp_length / 2 + 1),
+    )
+
+    hctilde = lal.CreateCOMPLEX16FrequencySeries(
+        "FD H_CROSS",
+        hc_ts.epoch,
+        0.0,
+        delta_f,
+        lal.DimensionlessUnit,
+        int(chirp_length / 2 + 1),
+    )
+
+    plan = lal.CreateForwardREAL8FFTPlan(chirp_length, 0)
+    lal.REAL8TimeFreqFFT(hptilde, hp_ts, plan)
+    lal.REAL8TimeFreqFFT(hctilde, hc_ts, plan)
+
+    frequency_array = numpy.arange(len(hptilde.data.data)) * hptilde.deltaF
+    return frequency_array, hptilde, hctilde
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# NR-specific helpers
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def default_mode_array(ellmax, load_m0=False):
+    """
+    The (l, m) list that PyART's catalog loaders build, repeated here so the
+    caller can ask for a subset without reaching into them.
+    """
+    return [
+        (l, m)
+        for l, m in product(range(2, ellmax + 1), range(-ellmax, ellmax + 1))
+        if (m != 0 or load_m0) and l >= numpy.abs(m)
+    ]
+
+
+def invariant_amplitude(hlm, mode_array):
+    """
+    sqrt(sum_lm |h_lm|^2): the frame-invariant amplitude, whose peak is what LAL
+    call t = 0.
+    """
+    amplitude = 0.0
+    for mode in mode_array:
+        amplitude = amplitude + numpy.abs(hlm[tuple(mode)]["A"]) ** 2
+    return numpy.sqrt(amplitude)
+
+
+def estimate_time_of_maximum_amplitude(time_array, hlm, mode_array, precision=1e-3):
+    """
+    identical to what is done in pyseobnr
+    """
+    invariant_amp = invariant_amplitude(hlm, mode_array)
+    assert len(invariant_amp) == len(time_array)
+    amplitude_interpolator = CubicSpline(time_array, invariant_amp)
+
+    index_of_peak_amplitude = int(numpy.argmax(invariant_amp))
+    coarse_peak_time = time_array[index_of_peak_amplitude]
+
+    # local spacing: the grid need not be uniform (SXS output is adaptive)
+    i = min(index_of_peak_amplitude, len(time_array) - 2)
+    delta_t = time_array[i + 1] - time_array[i]
+
+    step = min(precision, delta_t / 10.0)
+    fine_peak_time = numpy.arange(
+        coarse_peak_time - delta_t, coarse_peak_time + delta_t, step
+    )
+    amplitude_fine = amplitude_interpolator(fine_peak_time)
+    return float(fine_peak_time[numpy.argmax(amplitude_fine)])
+
+
+def trim_nr_junk_and_drift(u, hlm, mode_array, peak_u, t_final=None, t_after_peak=None):
+    """
+    Drop the tail of the NR record.
+
+    GRAthena++ ringdowns drift at late times.
+    Two ways to cut it, both in geometric units (M):
+
+    t_final      : absolute cut in the catalogue's own retarded time u.
+    t_after_peak : cut this many M after the invariant-amplitude peak. Anchored
+                   to the merger rather than to the end of the file, so it
+                   survives a change of cut_U or resolution.
+
+    If both are given, the earlier of the two wins!
+
+    Returns
+    -------
+    u, hlm : the trimmed time array and mode dict (a new dict; the input, which
+             is owned by the cached Waveform object, is not modified).
+    """
+    keep = numpy.ones(len(u), dtype=bool)
+    if t_final is not None:
+        keep &= u <= t_final
+    if t_after_peak is not None:
+        keep &= u <= peak_u + t_after_peak
+
+    if keep.all():
+        return u, hlm
+
+    if not keep.any():
+        raise RuntimeError(
+            f"t_final={t_final} / t_after_peak={t_after_peak} removed the whole "
+            f"waveform (u spans [{u[0]:.1f}, {u[-1]:.1f}], peak at {peak_u:.1f})"
+        )
+
+    logger.debug(
+        "trimming NR data at u <= %.1f M (was %.1f M): %d of %d samples kept",
+        u[keep][-1],
+        u[-1],
+        keep.sum(),
+        len(u),
+    )
+    trimmed = {
+        tuple(mode): {k: v[keep] for k, v in hlm[tuple(mode)].items()}
+        for mode in mode_array
+    }
+    return u[keep], trimmed
+
+
+def compute_polarisations_from_modes(hlm, mode_array, iota, phase):
+    """
+    Sum the modes into polarisations.
+
+    The sum runs over *all* loaded modes, positive and negative m, so no
+    aligned-spin symmetry between h_lm and h_l-m is assumed (unlike
+    PyART.utils.wf_utils.compute_hphc, which does assume it and iterates
+    positive m only). That matters for precessing simulations.
+
+    The azimuthal angle is `phase` itself. Note that LAL uses pi/2 - phase
+    (SimInspiralChooseTDModes, and bilby.gw.source on top of it), as does PyART
+    in wf_utils.compute_hphc, so this convention differs from theirs by a
+    constant m*pi/2 per mode. That is immaterial when `phase` is sampled -- an NR
+    simulation carries its own arbitrary orbital phase anyway, so there is
+    already a constant offset from LAL's phiRef -- but it does mean this model
+    cannot be compared against a LAL approximant at fixed `phase`.
+    """
+    signal = 0.0 + 0.0j
+    for mode in mode_array:
+        ell, emm = int(mode[0]), int(mode[1])
+        ylm = lal.SpinWeightedSphericalHarmonic(iota, numpy.pi/2 - phase, -2, ell, emm)
+        signal = signal + ylm * hlm[(ell, emm)]
+    return numpy.real(signal), -numpy.imag(signal)
+
+
+def interpolate_modes(u, hlm, mode_array, new_u):
+    """
+    Returns a plain {(l, m): complex ndarray} dict.
+    """
+    from scipy.interpolate import CubicSpline
+
+    out = {}
+    for mode in mode_array:
+        key = tuple(mode)
+        # Adopted Cubic spline rather than what PyART does here:
+        # https://github.com/RoxGamba/PyART/blob/05bb78ff58b73f0a2480fdbcbc010d0cf71d950f/PyART/waveform.py#L502
+        # amplitude = numpy.interp(new_u, u, hlm[key]["A"])
+        # phase = numpy.interp(new_u, u, hlm[key]["p"])
+        amplitude = CubicSpline(u, hlm[key]["A"])(new_u)
+        phase = CubicSpline(u, hlm[key]["p"])(new_u)
+        out[key] = amplitude * numpy.exp(-1j * phase)
+    return out
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Catalogue loading (memoised: the likelihood must not touch the disk)
+# ─────────────────────────────────────────────────────────────────────────────
+
+_WAVEFORM_CACHE = {}
+
+# Per-catalogue defaults for the late-time trim. GRAthena++ ringdowns drift, so
+# that catalogue gets a merger-anchored cut by default; SXS does not need one.
+_DEFAULT_T_AFTER_PEAK = {"sxs": None, "gra": 100.0}
+
+
+def load_nr_waveform(**waveform_arguments):
+    """
+    Return a PyART Waveform for the requested simulation, loading it at most once.
+    """
+    catalog = str(waveform_arguments["catalog"]).lower()
+    ID = waveform_arguments["ID"]
+    if isinstance(ID, int):
+        ID = f"{ID:04}"
+    path = waveform_arguments["path"]
+    ellmax = waveform_arguments.get("ellmax", 4)
+    cut_U = waveform_arguments.get("cut_U", None)
+    load_m0 = waveform_arguments.get("load_m0", True)
+    download = waveform_arguments.get("download", False)
+
+    if catalog == "sxs":
+        order = waveform_arguments.get("order", 2)
+        level = waveform_arguments.get("level", None)
+        key = ("sxs", ID, path, ellmax, cut_U, load_m0, order, level)
+    elif catalog == "gra":
+        ext = waveform_arguments.get("ext", "ext")
+        res = waveform_arguments.get("res", "128")
+        r_ext = waveform_arguments.get("r_ext", None)
+        key = ("gra", ID, path, ellmax, cut_U, load_m0, ext, res, r_ext)
+    else:
+        raise NotImplementedError(
+            f"Not implemented '{catalog}'. "
+            f"Ask someone to add support for catalog '{catalog}' or force Koustav to do it"
+        )
+
+    if key in _WAVEFORM_CACHE:
+        return _WAVEFORM_CACHE[key]
+
+    logger.info("loading %s simulation %s from %s", catalog.upper(), ID, path)
+    if catalog.lower() == "sxs":
+        from ..catalogs import sxs as sxs_catalog
+
+        waveform = sxs_catalog.Waveform_SXS(
+            path=path,
+            ID=ID,
+            order=order,
+            level=level,
+            ellmax=ellmax,
+            cut_U=cut_U,
+            load_m0=load_m0,
+            download=download,
+            nu_rescale=False,
+            load=["hlm", "metadata"],
+            ignore_deprecation=waveform_arguments.get("ignore_deprecation", True),
+        )
+    elif catalog.lower() == "gra":
+        from ..catalogs import gra as gra_catalog
+
+        waveform = gra_catalog.Waveform_GRA(
+            ID=ID,
+            path=path,
+            ellmax=ellmax,
+            ext=ext,
+            res=res,
+            r_ext=r_ext,
+            cut_U=cut_U,
+            download=download,
+            nu_rescale=False,
+        )
+    else:
+        raise ValueError(
+            f'Ask someone to add support for catalog "{catalog}" '
+            f"or force Koustav to do it"
+        )
+
+    _WAVEFORM_CACHE[key] = waveform
+    return waveform
+
+
+def clear_waveform_cache():
+    """Drop every memoised simulation. Mostly useful in tests."""
+    _WAVEFORM_CACHE.clear()
+
+
+def component_masses_and_spins(metadata, total_mass):
+    """
+    Who is fatter?
+    """
+    m1, m2 = float(metadata["m1"]), float(metadata["m2"])
+    mass_1 = total_mass * m1 / (m1 + m2)
+    mass_2 = total_mass * m2 / (m1 + m2)
+    spin_1x, spin_1y, spin_1z = (float(metadata["chi1x"]),
+        float(metadata["chi1y"]),
+        float(metadata["chi1z"]),
+    )
+    spin_2x, spin_2y, spin_2z = (float(metadata["chi2x"]),
+        float(metadata["chi2y"]),
+        float(metadata["chi2z"]),
+    )
+    if mass_1 < mass_2:
+        mass_1, mass_2 = mass_2, mass_1
+        spin_1x, spin_2x = spin_2x, spin_1x
+        spin_1y, spin_2y = spin_2y, spin_1y
+        spin_1z, spin_2z = spin_2z, spin_1z
+    return mass_1, mass_2, spin_1z, spin_2z
+
+
+def resolve_mode_array(waveform, waveform_arguments):
+    """The modes to sum: everything that was loaded, or the requested subset."""
+    mode_array = waveform_arguments.get("mode_array", None)
+    if mode_array is None:
+        return sorted(waveform.hlm.keys())
+    mode_array = [tuple(mode) for mode in mode_array]
+    missing = [mode for mode in mode_array if mode not in waveform.hlm]
+    if missing:
+        raise KeyError(f"modes {missing} were not loaded from the simulation")
+    return mode_array
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Bilby source models
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def nr_time_domain_polarisations(
+    total_mass,
+    luminosity_distance,
+    iota,
+    phase,
+    **waveform_arguments,
+):
+    """
+    The NR polarisations in SI units, on a uniform grid, with t = 0 at the peak
+    of the invariant amplitude -- and *before* any of the LAL conditioning.
+
+    Returns
+    -------
+    time : ndarray
+        Seconds, uniformly spaced, negative before the merger.
+    hplus, hcross : ndarray
+        Dimensionless strain at ``luminosity_distance``.
+    """
+    sampling_frequency = waveform_arguments["sampling_frequency"]
+
+    waveform = load_nr_waveform(**waveform_arguments)
+    catalog = str(waveform_arguments["catalog"]).lower()
+    mode_array = resolve_mode_array(waveform, waveform_arguments)
+
+    geometric_to_seconds = total_mass * lal.MTSUN_SI
+    distance_in_metres = luminosity_distance * 1e6 * lal.PC_SI
+
+    u = numpy.asarray(waveform.u)
+    # Centre t = 0 on the peak of the invariant amplitude, which is where LAL
+    # put it, then drop the late-time tail if requested.
+    peak_u = estimate_time_of_maximum_amplitude(u, waveform.hlm, mode_array)
+    t_after_peak = waveform_arguments.get(
+        "t_after_peak", _DEFAULT_T_AFTER_PEAK[catalog]
+    )
+    u, hlm = trim_nr_junk_and_drift(
+        u,
+        waveform.hlm,
+        mode_array,
+        peak_u,
+        t_final=waveform_arguments.get("t_final", None),
+        t_after_peak=t_after_peak,
+    )
+
+    times = (u - peak_u) * geometric_to_seconds
+
+    delta_t = 1.0 / sampling_frequency
+    time = numpy.arange(times[0], times[-1], delta_t)
+    hlm_interpolated = interpolate_modes(times, hlm, mode_array, time)
+
+    hplus, hcross = compute_polarisations_from_modes(
+        hlm_interpolated, mode_array, iota, phase
+    )
+    amplitude_scale = geometric_to_seconds * lal.C_SI / distance_in_metres
+    return time, hplus * amplitude_scale, hcross * amplitude_scale
+
+
+def nr_frequency_domain_source_model(
+    frequency_array,
+    total_mass,
+    luminosity_distance,
+    iota,
+    phase,
+    **waveform_arguments,
+):
+    """
+    A bilby frequency_domain_source_model backed by an NR simulation.
+
+    Parameters
+    ----------
+    frequency_array : ndarray
+        Bilby's frequency grid.
+    total_mass : float
+        Total mass of the binary in solar masses.
+    luminosity_distance : float
+        Luminosity distance in Mpc.
+    iota : float
+        Inclination angle between the orbital angular momentum and the line of sight.
+    phase : float
+        Orbital phase. Note that phase = 0 does not single out any particular
+        orientation of the simulation: an NR run carries its own arbitrary
+        orbital phase at the reference time, so there is a constant offset
+        between this parameter and LAL's phiRef. That is harmless when phase is
+        sampled, but it means a fixed-phase comparison against an approximant
+        has to search over it -- with only the (2, +-2) modes the offset is
+        degenerate with the overall phase, but with higher modes it is not.
+    waveform_arguments : dict
+        Required: ``catalog``, ``ID``, ``path``, ``minimum_frequency``,
+        ``maximum_frequency``, ``sampling_frequency``.
+        Optional: ``ellmax`` (4), ``load_m0`` (True), ``cut_U``, ``t_final``,
+        ``t_after_peak``, ``mode_array``, ``download``, plus the
+        catalogue-specific keys accepted by :func:`load_nr_waveform`.
+
+    Returns
+    -------
+    dict with keys 'plus' and 'cross'.
+    """
+    minimum_frequency = waveform_arguments["minimum_frequency"]
+    maximum_frequency = waveform_arguments["maximum_frequency"]
+    sampling_frequency = waveform_arguments["sampling_frequency"]
+    delta_f = frequency_array[1] - frequency_array[0]
+
+    waveform = load_nr_waveform(**waveform_arguments)
+    mass_1, mass_2, spin_1z, spin_2z = component_masses_and_spins(
+        waveform.metadata, total_mass
+    )
+
+    binary_parameters = {
+        "mass1": mass_1,
+        "mass2": mass_2,
+        "spin1z": spin_1z,
+        "spin2z": spin_2z,
+        "f_lower": minimum_frequency,
+    }
+    _, _, fico, chirp_time, extra_time, extra_time_fraction = (
+        compute_conditioning_parameters(binary_parameters)
+    )
+
+    time, hplus, hcross = nr_time_domain_polarisations(
+        total_mass, luminosity_distance, iota, phase, **waveform_arguments
+    )
+    delta_t = 1.0 / sampling_frequency
+    lal_epoch = lal.LIGOTimeGPS(float(time[0]))
+
+    # SimInspiralFD generates from a frequency low enough that the taper below
+    # has somewhere to act. An NR record is however long it is, and if it is
+    # shorter than the taper, SimInspiralTDConditionStage1 aborts the process
+    # rather than returning an error -- so check here, where we can still say
+    # something useful.
+    taper_length = extra_time_fraction * chirp_time + extra_time
+    record_length = float(time[-1] - time[0])
+    if record_length <= taper_length:
+        raise ValueError(
+            f"the NR record is {record_length:.3f} s long at M = {total_mass:.1f} "
+            f"Msun, but the SimInspiralFD conditioning wants to taper "
+            f"{taper_length:.3f} s of it at minimum_frequency = "
+            f"{minimum_frequency:.1f} Hz. Raise the total mass, raise "
+            f"minimum_frequency, or use a longer simulation."
+        )
+
+    # Same treatment before Fourier transforming as SimInspiralFD applies.
+    # Stage-1: taper the initial extra segment before f_min, high-pass at f_min
+    # and remove zero-padding. Stage-2: taper one cycle at f_min from the start
+    # and one at f_ISCO from the end, to kill the filter transients.
+    # https://github.com/lscsoft/lalsuite/blob/06047f8491f5cf480c720b47e2ad7bf85b26adc4/lalsimulation/lib/LALSimInspiral.c#L5504
+    time_length = len(hplus)
+    hp_ts = lal.CreateREAL8TimeSeries(
+        "hplus", lal_epoch, 0, delta_t, lal.DimensionlessUnit, time_length
+    )
+    hc_ts = lal.CreateREAL8TimeSeries(
+        "hcross", lal_epoch, 0, delta_t, lal.DimensionlessUnit, time_length
+    )
+    hp_ts.data.data[:] = hplus
+    hc_ts.data.data[:] = hcross
+
+    lalsimulation.SimInspiralTDConditionStage1(
+        hp_ts, hc_ts, extra_time_fraction * chirp_time + extra_time, minimum_frequency
+    )
+    lalsimulation.SimInspiralTDConditionStage2(hp_ts, hc_ts, minimum_frequency, fico)
+
+    _, hptilde, hctilde = get_frequency_domain_polarisations(
+        hp_ts, hc_ts, sampling_frequency, delta_f, maximum_frequency=maximum_frequency
+    )
+
+    hplus_output = numpy.zeros_like(frequency_array, dtype=complex)
+    hcross_output = numpy.zeros_like(frequency_array, dtype=complex)
+    n = len(frequency_array)
+    if len(hptilde.data.data) > n:
+        hplus_output = hptilde.data.data[:n].copy()
+        hcross_output = hctilde.data.data[:n].copy()
+    else:
+        hplus_output[: len(hptilde.data.data)] = hptilde.data.data
+        hcross_output[: len(hctilde.data.data)] = hctilde.data.data
+
+    frequency_bounds = (frequency_array >= minimum_frequency) & (
+        frequency_array <= maximum_frequency
+    )
+    hplus_output *= frequency_bounds
+    hcross_output *= frequency_bounds
+
+    # Time shift: move the merger to t = 0, exactly as bilby does on the
+    # SimInspiralFD branch of _base_lal_cbc_fd_waveform.
+    dt = (
+        1.0 / hptilde.deltaF
+        + hptilde.epoch.gpsSeconds
+        + hptilde.epoch.gpsNanoSeconds * 1e-9
+    )
+    time_shift = numpy.exp(-2j * numpy.pi * frequency_array[frequency_bounds] * dt)
+    hplus_output[frequency_bounds] *= time_shift
+    hcross_output[frequency_bounds] *= time_shift
+
+    return dict(plus=hplus_output, cross=hcross_output)
+
+
+def sxs_frequency_domain_source_model(
+    frequency_array,
+    total_mass,
+    luminosity_distance,
+    iota,
+    phase,
+    **waveform_arguments,
+):
+    """:func:`nr_frequency_domain_source_model` pinned to the SXS catalogue."""
+    waveform_arguments["catalog"] = "sxs"
+    return nr_frequency_domain_source_model(
+        frequency_array,
+        total_mass,
+        luminosity_distance,
+        iota,
+        phase,
+        **waveform_arguments,
+    )
+
+
+def gra_frequency_domain_source_model(
+    frequency_array,
+    total_mass,
+    luminosity_distance,
+    iota,
+    phase,
+    **waveform_arguments,
+):
+    """:func:`nr_frequency_domain_source_model` pinned to the GRAthena++ catalogue."""
+    waveform_arguments["catalog"] = "gra"
+    return nr_frequency_domain_source_model(
+        frequency_array,
+        total_mass,
+        luminosity_distance,
+        iota,
+        phase,
+        **waveform_arguments,
+    )

--- a/PyART/plugin/bilby_plugin.py
+++ b/PyART/plugin/bilby_plugin.py
@@ -261,22 +261,6 @@ def trim_nr_junk_and_drift(u, hlm, mode_array, peak_u, t_final=None, t_after_pea
 
 
 def compute_polarisations_from_modes(hlm, mode_array, iota, phase):
-    """
-    Sum the modes into polarisations.
-
-    The sum runs over *all* loaded modes, positive and negative m, so no
-    aligned-spin symmetry between h_lm and h_l-m is assumed (unlike
-    PyART.utils.wf_utils.compute_hphc, which does assume it and iterates
-    positive m only). That matters for precessing simulations.
-
-    The azimuthal angle is `phase` itself. Note that LAL uses pi/2 - phase
-    (SimInspiralChooseTDModes, and bilby.gw.source on top of it), as does PyART
-    in wf_utils.compute_hphc, so this convention differs from theirs by a
-    constant m*pi/2 per mode. That is immaterial when `phase` is sampled -- an NR
-    simulation carries its own arbitrary orbital phase anyway, so there is
-    already a constant offset from LAL's phiRef -- but it does mean this model
-    cannot be compared against a LAL approximant at fixed `phase`.
-    """
     signal = 0.0 + 0.0j
     for mode in mode_array:
         ell, emm = int(mode[0]), int(mode[1])

--- a/PyART/utils/utils.py
+++ b/PyART/utils/utils.py
@@ -1256,6 +1256,55 @@ def extract_value_from_str(string, key):
     return None
 
 
+def refine_extremum(x, y, idx, window=5, find_max=True):
+    """
+    Sub-sample refinement of the extremum of y located at index idx.
+
+    A cubic spline is fitted over [idx-window, idx+window] and the extremum is
+    taken at the root of its derivative. This is more accurate than the grid
+    point x[idx], whose error is O(dx), and it does not require x to be
+    uniformly spaced.
+
+    Parameters
+    ----------
+    x : np.ndarray
+        Abscissa (need not be uniformly spaced)
+    y : np.ndarray
+        Ordinate
+    idx : int
+        Index of the discrete extremum to refine
+    window : int, optional
+        Number of points on each side of idx used for the local spline
+        (default: 5)
+    find_max : bool, optional
+        If True refine a maximum, otherwise a minimum (default: True)
+
+    Returns
+    -------
+    out : (x_ref, y_ref)
+        Refined position and value. Falls back to (x[idx], y[idx]) when fewer
+        than 4 points are available or the spline derivative has no root inside
+        the window.
+    """
+    i1 = max(idx - window, 0)
+    i2 = min(idx + window + 1, len(x))
+    xloc = x[i1:i2]
+    yloc = y[i1:i2]
+
+    if len(xloc) < 4:  # need at least 4 points for cubic
+        return float(x[idx]), float(y[idx])
+
+    cs = interpolate.CubicSpline(xloc, yloc)
+    roots = cs.derivative().roots(extrapolate=False)
+    roots = roots[(roots >= xloc[0]) & (roots <= xloc[-1])]
+    if len(roots) == 0:
+        return float(x[idx]), float(y[idx])
+
+    vals = cs(roots)
+    i_best = np.argmax(vals) if find_max else np.argmin(vals)
+    return float(roots[i_best]), float(vals[i_best])
+
+
 def get_radial_turning_points(t, r, window=5):
     """
     Find apastra/periastra passages given time and radius.
@@ -1287,30 +1336,9 @@ def get_radial_turning_points(t, r, window=5):
     tpe = t[idxpe].astype(float)
 
     def refine_local(idx, find_max=True):
-        refined = []
-        for i in idx:
-            # local window around i
-            i1 = max(i - window, 0)
-            i2 = min(i + window + 1, len(t))
-            tloc = t[i1:i2]
-            rloc = r[i1:i2]
-
-            if len(tloc) < 4:  # need at least 4 points for cubic
-                refined.append(t[i])
-                continue
-            cs = interpolate.CubicSpline(tloc, rloc)
-            csd = cs.derivative()
-            roots = csd.roots(extrapolate=False)
-            roots = roots[(roots >= tloc[0]) & (roots <= tloc[-1])]
-            if len(roots) == 0:
-                refined.append(t[i])
-                continue
-            vals = cs(roots)
-            if find_max:
-                refined.append(roots[np.argmax(vals)])
-            else:
-                refined.append(roots[np.argmin(vals)])
-        return np.array(refined)
+        return np.array(
+            [refine_extremum(t, r, i, window=window, find_max=find_max)[0] for i in idx]
+        )
 
     tap = refine_local(idxap, find_max=True)
     tpe = refine_local(idxpe, find_max=False)

--- a/PyART/utils/wf_utils.py
+++ b/PyART/utils/wf_utils.py
@@ -1,4 +1,6 @@
 import numpy as np
+from scipy.optimize import minimize_scalar
+
 from . import utils as ut
 
 
@@ -125,10 +127,36 @@ def k_to_emm(k):
     return MINDEX[k]
 
 
-def compute_hphc(hlm, phi=0, i=0, modes=[(2, 2)]):
+def invariant_amplitude(hlm, modes=None):
+    """
+    Frame-invariant amplitude sqrt(sum_lm |h_lm|^2).
+
+    Unlike the amplitude of a single multipole this does not depend on the
+    orientation of the frame, which is why its peak is the time origin used by
+    LAL (and hence by the NR source models).
+
+    Parameters
+    ----------
+    hlm: dict
+        dictionary with multipoles
+    modes: list or None
+        list of (ell, emm) tuples to include. If None, use every mode in hlm.
+    Returns
+    -------
+    out: ndarray
+        frame-invariant amplitude
+    """
+    if modes is None:
+        modes = list(hlm.keys())
+    amplitude = 0.0
+    for k in modes:
+        amplitude = amplitude + hlm[tuple(k)]["A"] ** 2
+    return np.sqrt(amplitude)
+
+
+def compute_hphc(hlm, phi=0, i=0, modes=[(2, 2)], assume_symmetry=True):
     """
     Compute hp and hc from hlm
-    for aligned spins, assuming usual symmetry between hlm and hl-m
 
     Parameters
     ----------
@@ -140,25 +168,41 @@ def compute_hphc(hlm, phi=0, i=0, modes=[(2, 2)]):
         inclination angle
     modes: list
         list of (ell, emm) tuples
+    assume_symmetry: bool
+        if True (default), assume the usual symmetry between hlm and hl-m, valid
+        for aligned spins: only the m>0 modes need to be passed, and the m<0
+        ones are reconstructed from them.
+        if False, sum the requested modes as they are, with no reconstruction.
+        This is the general case (e.g. precessing systems, or NR data where the
+        m<0 modes are loaded independently), but the caller is then responsible
+        for passing BOTH the m>0 and the m<0 modes -- passing only (2,2) yields
+        a circularly polarized waveform, not the physical pair.
     Returns
     -------
     out: (hp, hc)
         plus and cross polarizations
     """
     h = 0 + 1j * 0
-    for k in modes:
-        ell = k[0]
-        emm = k[1]
-        if emm != 0:
-            Alm = hlm[k]["A"]
-        else:
-            Alm = hlm[k]["z"] / 2
-        plm = hlm[k]["p"]
-        Hp = Alm * np.exp(-1j * plm)
-        Hn = (-1) ** ell * Alm * np.exp(1j * plm)
-        Ylmp = ut.spinsphericalharm(-2, ell, emm, np.pi / 2 - phi, i)
-        Ylmn = ut.spinsphericalharm(-2, ell, -emm, np.pi / 2 - phi, i)
-        h += Ylmp * Hp + Ylmn * Hn
+    if assume_symmetry:
+        for k in modes:
+            ell = k[0]
+            emm = k[1]
+            if emm != 0:
+                Alm = hlm[k]["A"]
+            else:
+                Alm = hlm[k]["z"] / 2
+            plm = hlm[k]["p"]
+            Hp = Alm * np.exp(-1j * plm)
+            Hn = (-1) ** ell * Alm * np.exp(1j * plm)
+            Ylmp = ut.spinsphericalharm(-2, ell, emm, np.pi / 2 - phi, i)
+            Ylmn = ut.spinsphericalharm(-2, ell, -emm, np.pi / 2 - phi, i)
+            h += Ylmp * Hp + Ylmn * Hn
+    else:
+        for k in modes:
+            ell = k[0]
+            emm = k[1]
+            Ylm = ut.spinsphericalharm(-2, ell, emm, np.pi / 2 - phi, i)
+            h += Ylm * hlm[tuple(k)]["z"]
 
     hp = np.real(h)
     hc = -np.imag(h)
@@ -227,7 +271,7 @@ def align_phase(t, Tf, phi_a_tau, phi_b):
     return np.sum(weight * (phi_a_tau - phi_b) * dt) / np.sum(weight * dt)
 
 
-def Align(t, Tf, tau_max, t_a, phi_a, t_b, phi_b):
+def Align(t, Tf, tau_max, t_a, phi_a, t_b, phi_b, refine=False, tau_tol=1e-12):
     r"""
     Align two waveforms in phase by minimizing the chi^2
 
@@ -261,6 +305,14 @@ def Align(t, Tf, tau_max, t_a, phi_a, t_b, phi_b):
         time array for second phase evolution
     phi_b: ndarray
         second phase evolution
+    refine: bool
+        if True, polish the best grid tau with a bounded scalar minimization
+        over one grid spacing on either side, so the result is not limited to
+        the sampling of t. The grid scan still runs first, which keeps the
+        search global: minimizing directly over the full (-tau_max, tau_max)
+        can settle in a 2*pi-aliased local minimum.
+    tau_tol: float
+        absolute tolerance on tau for the refinement
     Returns
     -------
     out: (tau_opt, dphi_opt, chi2_opt)
@@ -272,23 +324,50 @@ def Align(t, Tf, tau_max, t_a, phi_a, t_b, phi_b):
 
     res_phi_b = np.interp(t, t_b, phi_b)
 
+    def chi2_of_tau(tau_value):
+        res_phi_a_tau = np.interp(t, t_a + tau_value, phi_a)
+        dphi_value = align_phase(t, Tf, res_phi_a_tau, res_phi_b)
+        chi2_value = np.sum(weight * (res_phi_a_tau - res_phi_b - dphi_value) ** 2) * dt
+        return chi2_value, dphi_value
+
     tau = []
     dphi = []
     chi2 = []
     for i in range(-N, N):
         tau.append(i * dt)
-        res_phi_a_tau = np.interp(t, t_a + tau[-1], phi_a)
-        dphi.append(align_phase(t, Tf, res_phi_a_tau, res_phi_b))
-        chi2.append(np.sum(weight * (res_phi_a_tau - res_phi_b - dphi[-1]) ** 2) * dt)
+        chi2_value, dphi_value = chi2_of_tau(tau[-1])
+        dphi.append(dphi_value)
+        chi2.append(chi2_value)
 
     chi2 = np.array(chi2)
     imin = np.argmin(chi2)
-    return tau[imin], dphi[imin], chi2[imin]
+
+    if not refine:
+        return tau[imin], dphi[imin], chi2[imin]
+
+    solution = minimize_scalar(
+        lambda x: chi2_of_tau(x)[0],
+        bounds=(tau[imin] - dt, tau[imin] + dt),
+        method="bounded",
+        options={"xatol": tau_tol},
+    )
+    tau_opt = float(solution.x)
+    chi2_opt, dphi_opt = chi2_of_tau(tau_opt)
+    # the scan already gives the global basin; keep it if the polish did worse
+    if chi2_opt > chi2[imin]:
+        return tau[imin], dphi[imin], chi2[imin]
+    return tau_opt, dphi_opt, chi2_opt
 
 
 def remap(h_re, h_im):
     """
     Map (h_re, h_im) to (A, phi)
+
+    The convention is PyART's usual one, h = A exp(-i phi): for a complex
+    z = h_re + i h_im, this returns the same phase as
+    get_multipole_dict(z)["p"], since unwrap(angle(conj(z))) == -unwrap(angle(z)).
+    For polarizations (h = hp - i hc) call it as remap(hp, -hc).
+
     Parameters
     ----------
     h_re: ndarray
@@ -328,3 +407,253 @@ def shift_waveform(h_re, h_im, t_shift_idx, phi_shift):
     A, phi = remap(h_re, h_im)
     phi = phi - phi_shift
     return A * np.cos(phi), -A * np.sin(phi)
+
+
+#####################################################
+#   SimInspiralFD-style conditioning (needs LAL)    #
+#####################################################
+# These reproduce what LALSimulation's SimInspiralFD does to a time-domain
+# waveform before Fourier transforming it: taper the start, high-pass at f_min,
+# and taper the filter transients at both ends. They live here so that anything
+# generating a frequency-domain waveform from time-domain data -- the bilby NR
+# source models, and in principle the match code -- can share them.
+#
+# Much of this is adapted from pyseobnr:
+#   https://github.com/AEI-ACR/pyseobnr/blob/70e730002061210264dcc297d01e6b4c8c5a0bc1/pyseobnr/generate_waveform.py#L1258
+#
+# Note this is a different thing from analysis.match.condition_td_waveform,
+# which pads and Tukey-tapers a pycbc TimeSeries around the merger for mismatch
+# computations. The two are deliberately kept separate.
+#
+# lal/lalsimulation are imported inside the functions: PyART.waveform imports
+# this module, and `import PyART` should not require LAL to be installed.
+
+
+def compute_conditioning_parameters(
+    mass_1,
+    mass_2,
+    spin_1z,
+    spin_2z,
+    minimum_frequency,
+    extra_time_fraction=0.1,
+    extra_cycles=3.0,
+):
+    """
+    Time and frequency bounds used by the SimInspiralFD conditioning.
+
+    Parameters
+    ----------
+    mass_1, mass_2: float
+        component masses in Solar masses
+    spin_1z, spin_2z: float
+        dimensionless spin components along the orbital angular momentum
+    minimum_frequency: float
+        requested lower frequency of the analysis, in Hz
+    extra_time_fraction: float
+        fraction of the chirp time used for the Stage-1 taper
+    extra_cycles: float
+        number of cycles at f_lower prepended before the waveform
+
+    Returns
+    -------
+    f_start : float
+        lower starting frequency for the TD waveform call (includes extra time)
+    f_lower : float
+        effective minimum frequency used for the chirp-time bound; equal to
+        min(minimum_frequency, ISCO_9M), following the SimInspiralFD convention
+    f_isco : float
+        Schwarzschild ISCO frequency, used for Stage 2
+    chirp_time : float
+        chirp time at f_lower
+    extra_time : float
+        extra time (extra_cycles / f_lower) prepended before the waveform
+    extra_time_fraction : float
+        echoed back, so callers can rebuild the taper length
+    """
+    import lal
+    import lalsimulation
+
+    # SimInspiralFD uses r = 9M ISCO to decide whether to lower f_min.
+    fico_check = 1.0 / (pow(9.0, 1.5) * np.pi * (mass_1 + mass_2) * lal.MTSUN_SI)
+    f_lower = min(minimum_frequency, fico_check)
+
+    # Schwarzschild (r = 6M) ISCO for Stage 2.
+    f_isco = 1.0 / (pow(6.0, 1.5) * np.pi * (mass_1 + mass_2) * lal.MTSUN_SI)
+
+    chirp_time = lalsimulation.SimInspiralChirpTimeBound(
+        f_lower, mass_1 * lal.MSUN_SI, mass_2 * lal.MSUN_SI, spin_1z, spin_2z
+    )
+
+    spinkerr = lalsimulation.SimInspiralFinalBlackHoleSpinBound(spin_1z, spin_2z)
+    tmerge = lalsimulation.SimInspiralMergeTimeBound(
+        mass_1 * lal.MSUN_SI, mass_2 * lal.MSUN_SI
+    ) + lalsimulation.SimInspiralRingdownTimeBound(
+        (mass_1 + mass_2) * lal.MSUN_SI, spinkerr
+    )
+
+    extra_time = extra_cycles / f_lower
+    f_start = lalsimulation.SimInspiralChirpStartFrequencyBound(
+        (1.0 + extra_time_fraction) * chirp_time + tmerge + extra_time,
+        mass_1 * lal.MSUN_SI,
+        mass_2 * lal.MSUN_SI,
+    )
+
+    return f_start, f_lower, f_isco, chirp_time, extra_time, extra_time_fraction
+
+
+def condition_td_polarisations(
+    hp,
+    hc,
+    delta_t,
+    epoch,
+    minimum_frequency,
+    chirp_time,
+    extra_time,
+    f_isco,
+    extra_time_fraction=0.1,
+):
+    """
+    Apply the SimInspiralFD conditioning to time-domain polarizations.
+
+    Stage 1 tapers the initial extra segment before f_min, high-passes at f_min
+    and removes the zero padding. Stage 2 tapers one cycle at f_min from the
+    start and one at f_ISCO from the end, killing the filter transients.
+    https://github.com/lscsoft/lalsuite/blob/06047f8491f5cf480c720b47e2ad7bf85b26adc4/lalsimulation/lib/LALSimInspiral.c#L5504
+
+    Parameters
+    ----------
+    hp, hc: ndarray
+        time-domain polarizations, uniformly sampled at delta_t
+    delta_t: float
+        sampling interval in seconds
+    epoch: float
+        GPS time of the first sample, in seconds
+    minimum_frequency: float
+        lower frequency of the analysis, in Hz
+    chirp_time, extra_time, f_isco, extra_time_fraction:
+        as returned by compute_conditioning_parameters
+
+    Returns
+    -------
+    out: (hp_ts, hc_ts)
+        conditioned LAL REAL8TimeSeries
+
+    Raises
+    ------
+    ValueError
+        if the record is shorter than the Stage-1 taper. SimInspiralFD generates
+        from a frequency low enough that the taper has somewhere to act; a
+        pre-existing record (e.g. an NR simulation) is however long it is, and
+        SimInspiralTDConditionStage1 aborts the process rather than returning an
+        error, so the check has to happen here.
+    """
+    import lal
+    import lalsimulation
+
+    taper_length = extra_time_fraction * chirp_time + extra_time
+    record_length = len(hp) * delta_t
+    if record_length <= taper_length:
+        raise ValueError(
+            f"the record is {record_length:.3f} s long, but the SimInspiralFD "
+            f"conditioning wants to taper {taper_length:.3f} s of it at "
+            f"minimum_frequency = {minimum_frequency:.1f} Hz. Raise the total "
+            f"mass, raise minimum_frequency, or use a longer waveform."
+        )
+
+    lal_epoch = lal.LIGOTimeGPS(float(epoch))
+    length = len(hp)
+    hp_ts = lal.CreateREAL8TimeSeries(
+        "hplus", lal_epoch, 0, delta_t, lal.DimensionlessUnit, length
+    )
+    hc_ts = lal.CreateREAL8TimeSeries(
+        "hcross", lal_epoch, 0, delta_t, lal.DimensionlessUnit, length
+    )
+    hp_ts.data.data[:] = hp
+    hc_ts.data.data[:] = hc
+
+    lalsimulation.SimInspiralTDConditionStage1(
+        hp_ts, hc_ts, taper_length, minimum_frequency
+    )
+    lalsimulation.SimInspiralTDConditionStage2(hp_ts, hc_ts, minimum_frequency, f_isco)
+    return hp_ts, hc_ts
+
+
+def fd_polarisations_from_td(
+    hp_ts, hc_ts, sampling_frequency, delta_f, maximum_frequency=None
+):
+    """
+    Resize conditioned TD polarizations to a power-of-2 chirp length and FFT
+    them with LAL's REAL8TimeFreqFFT.
+
+    Adapted from:
+    https://github.com/AEI-ACR/pyseobnr/blob/70e730002061210264dcc297d01e6b4c8c5a0bc1/pyseobnr/generate_waveform.py#L1333
+
+    Parameters
+    ----------
+    hp_ts, hc_ts: lal.REAL8TimeSeries
+        conditioned time-domain polarizations
+    sampling_frequency: float
+        sampling rate in Hz
+    delta_f: float
+        frequency spacing of the output; 0 means "use the natural resolution"
+    maximum_frequency: float or None
+        upper frequency of the analysis, in Hz (default: Nyquist)
+
+    Returns
+    -------
+    frequency_array : ndarray
+        one-sided frequencies [0 .. Nyquist]
+    hptilde, hctilde : lal.COMPLEX16FrequencySeries
+        one-sided frequency-domain polarizations
+    """
+    import lal
+
+    nyquist = sampling_frequency // 2
+    if maximum_frequency is None:
+        maximum_frequency = nyquist
+
+    if delta_f != 0:
+        n = int(np.round(maximum_frequency / delta_f))
+        if n & (n - 1):
+            exp = np.frexp(n)
+            nyquist = np.ldexp(1, int(exp[1])) * delta_f
+
+    delta_t = 0.5 / nyquist
+
+    if delta_f == 0:
+        chirp_length = hp_ts.data.length
+        exp = np.frexp(chirp_length)
+        chirp_length = int(np.ldexp(1, int(exp[1])))
+        delta_f = 1.0 / (chirp_length * delta_t)
+    else:
+        chirp_length = int(1.0 / (delta_f * delta_t))
+
+    # Keep the last chirp_length samples (i.e. keep the merger / ringdown).
+    # When the waveform is shorter than the segment the first argument is
+    # negative and LAL prepends zeros, which is what we want.
+    lal.ResizeREAL8TimeSeries(hp_ts, hp_ts.data.length - chirp_length, chirp_length)
+    lal.ResizeREAL8TimeSeries(hc_ts, hc_ts.data.length - chirp_length, chirp_length)
+
+    hptilde = lal.CreateCOMPLEX16FrequencySeries(
+        "FD H_PLUS",
+        hp_ts.epoch,
+        0.0,
+        delta_f,
+        lal.DimensionlessUnit,
+        int(chirp_length / 2 + 1),
+    )
+    hctilde = lal.CreateCOMPLEX16FrequencySeries(
+        "FD H_CROSS",
+        hc_ts.epoch,
+        0.0,
+        delta_f,
+        lal.DimensionlessUnit,
+        int(chirp_length / 2 + 1),
+    )
+
+    plan = lal.CreateForwardREAL8FFTPlan(chirp_length, 0)
+    lal.REAL8TimeFreqFFT(hptilde, hp_ts, plan)
+    lal.REAL8TimeFreqFFT(hctilde, hc_ts, plan)
+
+    frequency_array = np.arange(len(hptilde.data.data)) * hptilde.deltaF
+    return frequency_array, hptilde, hctilde

--- a/PyART/waveform.py
+++ b/PyART/waveform.py
@@ -99,6 +99,32 @@ class Waveform(object):
     def domain(self):
         return self._domain
 
+    def copy(self):
+        """
+        Return a copy of the waveform that is safe to mutate.
+
+        The full deepcopy is not used because catalog waveforms hold non-copyable
+        state (open h5py handles, an ``sxs.Coalescence`` object, ...). Instead
+        the object is shallow-copied.
+
+        - the mode dictionaries (``_hlm``/``_dothlm``/``_psi4lm``), whose inner
+          arrays are sliced in place by ``cut``;
+        - the time/frequency and polarization arrays, which are reassigned.
+
+        Returns
+        -------
+        out: Waveform
+            a copy that can be mutated without affecting self
+        """
+        wf = copy.copy(self)
+        for attr in ("_hlm", "_dothlm", "_psi4lm"):
+            wf.__dict__[attr] = copy.deepcopy(getattr(self, attr))
+        for attr in ("_u", "_t", "_t_psi4", "_hp", "_hc", "_f", "u_pc", "flm"):
+            val = getattr(self, attr, None)
+            if val is not None:
+                wf.__dict__[attr] = np.array(val, copy=True)
+        return wf
+
     # define multiplication and division by a factor
     # both methods return a new waveform object, without modifying the original one
     def __mul__(self, factor):
@@ -181,6 +207,9 @@ class Waveform(object):
         height=None,
         second_dvt=False,
         return_idx=False,
+        modes=None,
+        refine=False,
+        refine_window=5,
     ):
         """
         Find peak time, amplitude, frequency and frequency derivative
@@ -189,11 +218,16 @@ class Waveform(object):
         Parameters
         ----------
         mode: tuple
-            (l,m) mode to consider
+            (l,m) mode to consider. Also selects the multipole whose phase
+            gives omg/domg when `modes` is used (see below).
         kind: str
             'first-max-after-t': first maximum after umin
             'last-peak': last peak in the waveform
             'global': global maximum
+            'argmax': global maximum, taken directly with argmax rather than
+                      through scipy's find_peaks. Use this when the peak may sit
+                      at (or very near) an endpoint of the record, where
+                      find_peaks sees no peak at all and raises.
         wave: str
             'hlm' or 'psi4lm'
         umin: float
@@ -203,6 +237,17 @@ class Waveform(object):
             if None, set to mean(Alm)/2
         return_idx: bool
             if True, return also the index of the peak
+        modes: list or None
+            if None (default), the peak is searched on the amplitude of `mode`.
+            if a list of (l,m), it is searched on the frame-invariant amplitude
+            sqrt(sum_lm |h_lm|^2) instead, which is what LAL uses to define the
+            merger time. 
+        refine: bool
+            if True, refine the peak to sub-sample accuracy with a local cubic
+            spline (see utils.refine_extremum). The returned index, if
+            requested, stays the integer grid index.
+        refine_window: int
+            number of points on each side of the peak used by the refinement
         Returns
         -------
         out: (t_mrg, A_mrg, omg_mrg, domg_mrg[, idx])
@@ -220,8 +265,13 @@ class Waveform(object):
             t = self.u
 
         wave = getattr(self, wave)
+        if modes is None:
+            Alm = wave[mode]["A"]
+        else:
+            Alm = wf_ut.invariant_amplitude(wave, modes)
+            if mode not in wave:
+                mode = tuple(modes[0])
         p = wave[mode]["p"]
-        Alm = wave[mode]["A"]
 
         # D1 requires a uniform time grid, but the underlying data need not be
         # (e.g. SXS-native output has adaptive time stepping). Interpolate onto
@@ -256,35 +306,49 @@ class Waveform(object):
             d2Alm = from_grid(d2Alm_grid)
             domg2 = from_grid(domg2_grid)
 
-        # find peaks
-        if height is None:
-            height = np.mean(Alm) / 2
-        peaks, props = find_peaks(Alm, height=height)
-
-        if len(peaks) == 0:
-            raise ValueError("No peaks found")
-
-        if kind == "first-max-after-t":
-            after_umin = np.where(t[peaks] > umin)[0]
-            if len(after_umin) == 0:
-                raise ValueError(f"No peak found after umin={umin}")
-            i = after_umin[0]
-        elif kind == "last-peak":
-            i = len(peaks) - 1
-        elif kind == "global":
-            Alms = props["peak_heights"]
-            i = np.argmax(Alms)
+        # find the peak
+        if kind == "argmax":
+            i_peak = int(np.argmax(Alm))
         else:
-            raise ValueError("`kind' for merger not found")
+            if height is None:
+                height = np.mean(Alm) / 2
+            peaks, props = find_peaks(Alm, height=height)
 
-        t_mrg = t[peaks[i]]
-        A_mrg = Alm[peaks[i]]
-        omg_mrg = omg[peaks[i]]
-        domg_mrg = domg[peaks[i]]
-        if second_dvt:
-            dAlm_mrg = dAlm[peaks[i]]
-            d2Alm_mrg = d2Alm[peaks[i]]
-            domg2_mrg = domg2[peaks[i]]
+            if len(peaks) == 0:
+                raise ValueError("No peaks found")
+
+            if kind == "first-max-after-t":
+                after_umin = np.where(t[peaks] > umin)[0]
+                if len(after_umin) == 0:
+                    raise ValueError(f"No peak found after umin={umin}")
+                i = after_umin[0]
+            elif kind == "last-peak":
+                i = len(peaks) - 1
+            elif kind == "global":
+                Alms = props["peak_heights"]
+                i = np.argmax(Alms)
+            else:
+                raise ValueError("`kind' for merger not found")
+            i_peak = peaks[i]
+
+        if refine:
+            # sub-sample peak from a local cubic spline --- similar to pyseobnr
+            t_mrg, A_mrg = ut.refine_extremum(t, Alm, i_peak, window=refine_window)
+            omg_mrg = np.interp(t_mrg, t, omg)
+            domg_mrg = np.interp(t_mrg, t, domg)
+            if second_dvt:
+                dAlm_mrg = np.interp(t_mrg, t, dAlm)
+                d2Alm_mrg = np.interp(t_mrg, t, d2Alm)
+                domg2_mrg = np.interp(t_mrg, t, domg2)
+        else:
+            t_mrg = t[i_peak]
+            A_mrg = Alm[i_peak]
+            omg_mrg = omg[i_peak]
+            domg_mrg = domg[i_peak]
+            if second_dvt:
+                dAlm_mrg = dAlm[i_peak]
+                d2Alm_mrg = d2Alm[i_peak]
+                domg2_mrg = domg2[i_peak]
 
         if return_idx:
             if second_dvt:
@@ -296,10 +360,10 @@ class Waveform(object):
                     dAlm_mrg,
                     d2Alm_mrg,
                     domg2_mrg,
-                    peaks[i],
+                    i_peak,
                 )
             else:
-                return t_mrg, A_mrg, omg_mrg, domg_mrg, peaks[i]
+                return t_mrg, A_mrg, omg_mrg, domg_mrg, i_peak
         else:
             if second_dvt:
                 return t_mrg, A_mrg, omg_mrg, domg_mrg, dAlm_mrg, d2Alm_mrg, domg2_mrg
@@ -479,10 +543,10 @@ class Waveform(object):
 
         pass
 
-    def compute_hphc(self, phi=0, i=0, modes=[(2, 2)]):
+    def compute_hphc(self, phi=0, i=0, modes=[(2, 2)], assume_symmetry=True):
         """
-        For aligned spins, compute hp and hc
-        assuming usual symmetry between hlm and hl-m
+        Compute hp and hc from self.hlm
+
         Parameters
         ----------
         phi: float
@@ -491,34 +555,67 @@ class Waveform(object):
             inclination angle of the observer
         modes: list
             list of (l,m) modes to consider
+        assume_symmetry: bool
+            if True (default), assume the usual symmetry between hlm and hl-m,
+            valid for aligned spins: only the m>0 modes need to be passed.
+            if False, sum the requested modes as they are; the caller must then
+            pass both the m>0 and the m<0 modes. See wf_utils.compute_hphc.
         Returns
         -------
         out: (hp, hc)
             plus and cross polarizations
         """
-        self._hp, self._hc = wf_ut.compute_hphc(self.hlm, phi, i, modes)
+        self._hp, self._hc = wf_ut.compute_hphc(
+            self.hlm, phi, i, modes, assume_symmetry=assume_symmetry
+        )
         return self.hp, self.hc
 
-    def interpolate_hlm(self, dT):
+    def interpolate_hlm(self, dT=None, new_u=None, kind="linear", modes=None):
         """
-        Interpolate the hlm dictionary to a grid of uniform dT
+        Interpolate the hlm dictionary onto a new time grid.
+
+        Amplitude and phase are interpolated separately and recombined.
 
         Parameters
         ----------
-        dT: float
-            time step of the new grid
+        dT: float or None
+            time step of the new (uniform) grid, spanning self.u.
+            Exactly one of dT and new_u must be given.
+        new_u: array-like or None
+            explicit target grid, when it is not simply uniform in dT
+        kind: str
+            'linear' (default) uses np.interp; any other value is passed to
+            utils.spline (e.g. 'cubic'), which is more accurate on a coarse or
+            non-uniform source grid.
+        modes: list or None
+            (l,m) modes to interpolate. If None, every mode in self.hlm.
         Returns
         -------
         out: (new_u, hlm_i)
             new time array and interpolated hlm dictionary
         """
-        hlm_i = {}
-        new_u = np.arange(self.u[0], self.u[-1], dT)
+        if (dT is None) == (new_u is None):
+            raise ValueError("interpolate_hlm needs exactly one of dT and new_u")
 
-        for k in self.hlm.keys():
+        if new_u is None:
+            new_u = np.arange(self.u[0], self.u[-1], dT)
+        else:
+            new_u = np.asarray(new_u)
+
+        if modes is None:
+            modes = list(self.hlm.keys())
+
+        if kind == "linear":
+            resample = lambda y: np.interp(new_u, self.u, y)
+        else:
+            resample = lambda y: ut.spline(self.u, y, new_u, kind=kind)
+
+        hlm_i = {}
+        for k in modes:
+            k = tuple(k)
             h = self.hlm[k]["z"]
-            iA = np.interp(new_u, self.u, np.abs(h))
-            ip = np.interp(new_u, self.u, -np.unwrap(np.angle(h)))
+            iA = resample(np.abs(h))
+            ip = resample(-np.unwrap(np.angle(h)))
             ih = iA * np.exp(-1j * ip)
             hlm_i[k] = wf_ut.get_multipole_dict(ih)
 
@@ -723,7 +820,7 @@ class Waveform(object):
         self._psi4lm = psi4lm
         return mode.integr_opts
 
-    def to_geom(self, M, distance):
+    def to_geom(self, M, distance, inplace=True):
         """
         Convert waveform and time/freqs to geom units from SI
 
@@ -733,7 +830,16 @@ class Waveform(object):
             total mass of the system in Solar masses
         distance : float
             distance in Mpc
+        inplace : bool
+            if True (default), convert this object and return None.
+            if False, leave it untouched and return a converted copy -- use
+            this when the object is shared or cached (see Waveform.copy).
         """
+        if not inplace:
+            converted = self.copy()
+            converted.to_geom(M, distance)
+            return converted
+
         if self.units == "geom":
             raise RuntimeError("Already using geom units!")
 
@@ -774,7 +880,7 @@ class Waveform(object):
         self._units = "geom"
         pass
 
-    def to_SI(self, M, distance):
+    def to_SI(self, M, distance, inplace=True):
         """
         Convert waveform and time/freqs to SI units from geom
 
@@ -784,7 +890,16 @@ class Waveform(object):
             total mass of the system in Solar masses
         distance : float
             distance in Mpc
+        inplace : bool
+            if True (default), convert this object and return None.
+            if False, leave it untouched and return a converted copy -- use
+            this when the object is shared or cached (see Waveform.copy).
         """
+        if not inplace:
+            converted = self.copy()
+            converted.to_SI(M, distance)
+            return converted
+
         if self.units == "SI":
             raise RuntimeError("Already using SI units!")
 

--- a/PyART/waveform.py
+++ b/PyART/waveform.py
@@ -241,7 +241,7 @@ class Waveform(object):
             if None (default), the peak is searched on the amplitude of `mode`.
             if a list of (l,m), it is searched on the frame-invariant amplitude
             sqrt(sum_lm |h_lm|^2) instead, which is what LAL uses to define the
-            merger time. 
+            merger time.
         refine: bool
             if True, refine the peak to sub-sample accuracy with a local cubic
             spline (see utils.refine_extremum). The returned index, if

--- a/examples/bilby_nr_source_model.py
+++ b/examples/bilby_nr_source_model.py
@@ -1,0 +1,667 @@
+"""
+Validate the PyART bilby source model
+
+The GRAthena++ catalogue is arXiv:2411.11989: q = 1, 2, 3, 4, non-spinning,
+quasi-circular. The SXS partners are matched by mass ratio.
+
+Needs network access on the first run, to download the simulations.
+
+    python examples/bilby_nr_source_model.py --gra_id 0001
+"""
+
+import argparse
+import os
+import subprocess
+
+import numpy
+import matplotlib
+
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+from scipy.optimize import minimize_scalar
+
+import lal
+
+from PyART.logging_config import setup_logging
+from PyART.utils.wf_utils import align_phase
+from PyART.plugin.bilby_plugin import (
+    component_masses_and_spins,
+    compute_conditioning_parameters,
+    estimate_time_of_maximum_amplitude,
+    load_nr_waveform,
+    nr_frequency_domain_source_model,
+    nr_time_domain_polarisations,
+)
+
+setup_logging(level="INFO")
+
+# GRAthena++ ID -> the SXS simulation at the same mass ratio, all non-spinning.
+SXS_PARTNER = {
+    "0001": "1155",  # q = 1, 40.65 orbits, ecc 6.9e-06
+    "0002": "1167",  # q = 2, 40.52 orbits, ecc 3.6e-04
+    "0003": "1179",  # q = 3, 15.68 orbits, ecc 3.7e-05
+    "0004": "0167",  # q = 4, 15.59 orbits, ecc 9.5e-05
+}
+
+parser = argparse.ArgumentParser(description=__doc__)
+parser.add_argument("--gra-id", default="0001", help="GRAthena++ ID")
+parser.add_argument(
+    "--sxs-id", default=None, help="SXS ID (default: the partner of --gra-id)"
+)
+parser.add_argument("--res", default="128", help="GRAthena++ resolution")
+parser.add_argument("--ext", default="CCE", help="GRAthena++ extraction: ext, CCE or finite")
+parser.add_argument("--r-ext", default="50.00", help="GRAthena++ extraction radius")
+parser.add_argument(
+    "--total_mass",
+    type=float,
+    default=300.0,
+    help="Total mass (Msun). The default puts the whole GRAthena++ record inside "
+    "[f_min, f_max] while still leaving room for the conditioning taper: the "
+    "record starts at 20.4 Hz and the Stage-1 taper eats 0.25 s of 0.63 s. "
+    "Higher masses push the start of the record below f_min, lower ones leave "
+    "nothing after the taper.",
+)
+parser.add_argument("--distance", type=float, default=400.0, help="Distance (Mpc)")
+parser.add_argument(
+    "--iota",
+    type=float,
+    default=1.2,
+    help="Inclination (rad). Face-on by default: h+ - i hx is then a clean "
+    "circularly polarised chirp, so A and phi are unambiguous.",
+)
+parser.add_argument("--phase", type=float, default=0.0, help="Orbital phase (rad)")
+parser.add_argument("--ellmax", type=int, default=4, help="Maximum ell to load")
+parser.add_argument("--cut_U", type=float, default=200.0, help="Junk-radiation cut (M)")
+parser.add_argument(
+    "--t_after_peak", type=float, default=100.0, help="Keep this much after merger (M)"
+)
+parser.add_argument(
+    "--settle_cycles",
+    type=float,
+    default=0.5,
+    help="Extra cycles at f_min to skip after the Stage-1 taper, before the "
+    "comparison window starts",
+)
+parser.add_argument(
+    "--align_end_before",
+    type=float,
+    default=100.0,
+    help="End the alignment window this far before the merger (M)",
+)
+parser.add_argument("--duration", type=float, default=8.0, help="Segment duration (s)")
+parser.add_argument("--srate", type=float, default=4096.0, help="Sampling rate (Hz)")
+parser.add_argument(
+    "--f-min",
+    type=float,
+    default=15.0,
+    help="Minimum frequency (Hz). Must sit *below* the frequency at which the NR "
+    "record starts (20.4 Hz for GRAthena:BHBH:0001 at the default mass), or the "
+    "conditioning high-pass acts on the whole waveform rather than on the empty "
+    "band beneath it. --f_min_scan shows what that costs.",
+)
+parser.add_argument(
+    "--f-min-scan",
+    type=float,
+    nargs="*",
+    default=[15.0, 17.0, 20.0],
+    help="Extra f_min values to repeat the round-trip test at",
+)
+parser.add_argument(
+    "--f_max", type=float, default=1024.0, help="Maximum frequency (Hz)"
+)
+parser.add_argument("--no_plot", action="store_true", help="Skip the figures")
+args = parser.parse_args()
+
+sxs_id = args.sxs_id or SXS_PARTNER[args.gra_id]
+
+repo_path = (
+    subprocess.Popen(["git", "rev-parse", "--show-toplevel"], stdout=subprocess.PIPE)
+    .communicate()[0]
+    .rstrip()
+    .decode("utf-8")
+)
+out_path = os.path.join(repo_path, "examples/local_data/")
+
+frequency_array = numpy.arange(
+    0.0, args.srate / 2 + args.duration**-1, 1.0 / args.duration
+)
+band = (frequency_array >= args.f_min) & (frequency_array <= args.f_max)
+geometric_to_seconds = args.total_mass * lal.MTSUN_SI
+segment_time = (
+    numpy.arange(int(round(args.duration * args.srate))) / args.srate - args.duration
+)
+
+
+gra_path = os.path.join(repo_path, "examples/local_data/gra/")
+sxs_path = os.path.join(repo_path, "examples/local_data/sxs/")
+
+# Waveform_GRA re-fetches the whole resolution tarball every time it is
+# constructed with download=True -- it has no "already on disk" check, unlike
+# Waveform_SXS, and the archive is a few hundred MB. So decide from the
+# filesystem instead, and only ask for the download when the strain file that
+# will actually be read is missing.
+_gra_strain = {
+    "ext": "rh_Asymptotic_GeometricUnits.h5",
+    "CCE": "rh_CCE_GeometricUnits.h5",
+    "finite": "rh_FiniteRadii_GeometricUnits.h5",
+}[args.ext]
+downloaded = {
+    "gra": os.path.exists(
+        os.path.join(gra_path, f"GRA_BHBH_{args.gra_id}", args.res, _gra_strain)
+    ),
+    "sxs": False,
+}
+
+
+def gra_arguments(**overrides):
+    arguments = dict(
+        catalog="gra",
+        ID=args.gra_id,
+        path=gra_path,
+        download=not downloaded["gra"],
+        res=args.res,
+        ext=args.ext,
+        r_ext=args.r_ext,
+        ellmax=args.ellmax,
+        cut_U=args.cut_U,
+        t_after_peak=args.t_after_peak,
+        minimum_frequency=args.f_min,
+        maximum_frequency=args.f_max,
+        sampling_frequency=args.srate,
+    )
+    arguments.update(overrides)
+    return arguments
+
+
+def sxs_arguments(**overrides):
+    arguments = dict(
+        catalog="sxs",
+        ID=sxs_id,
+        path=sxs_path,
+        download=not downloaded["sxs"],
+        ellmax=args.ellmax,
+        load_m0=False,
+        cut_U=args.cut_U,
+        t_after_peak=args.t_after_peak,
+        minimum_frequency=args.f_min,
+        maximum_frequency=args.f_max,
+        sampling_frequency=args.srate,
+    )
+    arguments.update(overrides)
+    return arguments
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Amplitude, phase, and the alignment they are computed after
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def amplitude_and_phase(hplus, hcross):
+    """
+    A and phi of h = h+ - i hx, in PyART's convention (h = A exp(-i phi)).
+
+    Face-on this is exact: h is a circularly polarised chirp and A, phi are the
+    amplitude and phase of the (2, 2) mode. Off-axis the higher modes beat
+    against each other and A picks up a modulation -- still well defined, just
+    less clean to read.
+    """
+    signal = hplus - 1j * hcross
+    return numpy.abs(signal), -numpy.unwrap(numpy.angle(signal))
+
+
+def align(window, time_a, phase_a, time_b, phase_b, tau_max):
+    """
+    Align a onto b by minimising
+
+        chi2(tau) = int_window [ phi_a(t + tau) - phi_b(t) - dphi ]^2 dt
+
+    over the time shift tau and the phase offset dphi. dphi is solved
+    analytically at each tau by PyART.utils.wf_utils.align_phase; tau comes from
+    a bounded scalar minimisation, so it is sub-sample rather than limited to the
+    grid spacing (which is what PyART's own wf_utils.Align loop gives).
+
+    Returns (tau, dphi): evaluate a at t + tau and subtract dphi from its phase.
+    """
+    # align_phase weights on (t >= 0) & (t < Tf), so hand it a shifted window
+    local = window - window[0]
+    final = local[-1] + (local[1] - local[0])
+    resampled_b = numpy.interp(window, time_b, phase_b)
+
+    def chi2(tau):
+        shifted_a = numpy.interp(window, time_a + tau, phase_a)
+        offset = align_phase(local, final, shifted_a, resampled_b)
+        return float(numpy.sum((shifted_a - resampled_b - offset) ** 2))
+
+    solution = minimize_scalar(
+        chi2, bounds=(-tau_max, tau_max), method="bounded", options={"xatol": 1e-12}
+    )
+    tau = float(solution.x)
+    shifted_a = numpy.interp(window, time_a + tau, phase_a)
+    return tau, float(align_phase(local, final, shifted_a, resampled_b))
+
+
+def difference(
+    window, time_a, amplitude_a, phase_a, time_b, amplitude_b, phase_b, tau_max
+):
+    """
+    Align a onto b, then difference them on `window`.
+
+    Returns the alignment plus dA/A, dphi and |dh|/|h| as arrays over `window`.
+    """
+    tau, dphi = align(window, time_a, phase_a, time_b, phase_b, tau_max)
+
+    resampled_amplitude_a = numpy.interp(window, time_a + tau, amplitude_a)
+    resampled_phase_a = numpy.interp(window, time_a + tau, phase_a) - dphi
+    resampled_amplitude_b = numpy.interp(window, time_b, amplitude_b)
+    resampled_phase_b = numpy.interp(window, time_b, phase_b)
+
+    signal_a = resampled_amplitude_a * numpy.exp(-1j * resampled_phase_a)
+    signal_b = resampled_amplitude_b * numpy.exp(-1j * resampled_phase_b)
+
+    return dict(
+        tau=tau,
+        dphi=dphi,
+        window=window,
+        relative_amplitude=(resampled_amplitude_a - resampled_amplitude_b)
+        / resampled_amplitude_b,
+        phase_difference=resampled_phase_a - resampled_phase_b,
+        relative_strain=numpy.abs(signal_a - signal_b) / numpy.abs(signal_b),
+    )
+
+
+def difference_of_polarisations(
+    window, time_a, hplus_a, hcross_a, time_b, hplus_b, hcross_b, tau_max
+):
+    amplitude_a, phase_a = amplitude_and_phase(hplus_a, hcross_a)
+    amplitude_b, phase_b = amplitude_and_phase(hplus_b, hcross_b)
+    return difference(
+        window, time_a, amplitude_a, phase_a, time_b, amplitude_b, phase_b, tau_max
+    )
+
+
+def report(label, result, unit=""):
+    print(
+        f"  {label:30s} tau = {result['tau']:+.6e}{unit}   dphi = {result['dphi']:+.4f} rad\n"
+        f"  {'':30s} |dA/A|   max {numpy.max(numpy.abs(result['relative_amplitude'])):.3e}"
+        f"   rms {numpy.std(result['relative_amplitude']):.3e}\n"
+        f"  {'':30s} |dphi|   max {numpy.max(numpy.abs(result['phase_difference'])):.3e}"
+        f"   rms {numpy.std(result['phase_difference']):.3e}   rad\n"
+        f"  {'':30s} |dh|/|h| max {numpy.max(result['relative_strain']):.3e}"
+        f"   rms {numpy.std(result['relative_strain']):.3e}"
+    )
+
+
+def to_time_domain(strain):
+    """
+    Back to the time domain, on `segment_time`. The source model already zeroes
+    everything outside [f_min, f_max], so nothing more is masked here.
+    """
+    return numpy.fft.irfft(strain) * args.srate
+
+
+def instantaneous_frequency(time, hplus, hcross):
+    """GW frequency in Hz, from the derivative of the polarisation phase."""
+    _, phase = amplitude_and_phase(hplus, hcross)
+    return numpy.abs(numpy.gradient(phase, time)) / (2 * numpy.pi)
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Load both simulations and cut them to a common span before merger
+# ─────────────────────────────────────────────────────────────────────────────
+
+print(f"\nGRAthena:BHBH:{args.gra_id}  ({args.ext}, r = {args.r_ext}, res {args.res})")
+print(f"SXS:BBH:{sxs_id}")
+
+gra = load_nr_waveform(**gra_arguments())
+downloaded["gra"] = True
+sxs = load_nr_waveform(**sxs_arguments())
+downloaded["sxs"] = True
+
+print(
+    f"  q: GRA {gra.metadata['q']:.4f}, SXS {sxs.metadata['q']:.4f};  "
+    f"chi1z: GRA {gra.metadata['chi1z']:+.2e}, SXS {sxs.metadata['chi1z']:+.2e}"
+)
+if abs(gra.metadata["q"] - sxs.metadata["q"]) > 1e-3:
+    print("  WARNING: mass ratios differ -- the pairing table may be wrong.")
+
+
+def record_geometry(waveform):
+    """(u_start, u_peak, f_gw22 at the start) in geometric units."""
+    modes = sorted(waveform.hlm.keys())
+    peak = estimate_time_of_maximum_amplitude(waveform.u, waveform.hlm, modes)
+    n_edge = min(64, len(waveform.u) // 4)
+    frequency = numpy.abs(
+        numpy.median(
+            numpy.gradient(waveform.hlm[(2, 2)]["p"][:n_edge], waveform.u[:n_edge])
+        )
+    ) / (2 * numpy.pi)
+    return waveform.u[0], peak, frequency
+
+
+def describe(label, waveform):
+    start, peak, frequency = record_geometry(waveform)
+    print(
+        f"  {label:18s} {start:10.1f} {peak:10.1f} {peak - start:9.1f} "
+        f"{frequency:11.4e} {frequency / geometric_to_seconds:9.2f}"
+    )
+    return start, peak, frequency
+
+
+print(
+    f"\n{'':20s} {'u_start':>10s} {'u_peak':>10s} {'span':>9s} "
+    f"{'f_gw22 [M]':>11s} {'f [Hz]':>9s}"
+)
+gra_start, gra_peak, gra_frequency = describe("GRA before cut", gra)
+sxs_start, sxs_peak, sxs_frequency = describe("SXS before cut", sxs)
+
+# Take the shorter of the two spans before merger and cut the longer record to
+# match. Merger is the only time origin the two codes agree on.
+common_span = min(gra_peak - gra_start, sxs_peak - sxs_start)
+gra_kwargs = gra_arguments(cut_U=gra_peak - common_span)
+sxs_kwargs = sxs_arguments(cut_U=sxs_peak - common_span)
+gra = load_nr_waveform(**gra_kwargs)
+sxs = load_nr_waveform(**sxs_kwargs)
+gra_start, gra_peak, gra_frequency = describe("GRA after cut", gra)
+sxs_start, sxs_peak, sxs_frequency = describe("SXS after cut", sxs)
+
+print(
+    f"\n  common span before merger: {common_span:.1f} M = "
+    f"{common_span * geometric_to_seconds:.3f} s at M = {args.total_mass:.0f} Msun"
+)
+if abs(gra_frequency / sxs_frequency - 1) > 0.05:
+    print(
+        "  WARNING: the two records still start more than 5% apart in frequency; "
+        "the cut has not made them comparable."
+    )
+if min(gra_frequency, sxs_frequency) / geometric_to_seconds < args.f_min:
+    print(
+        f"  WARNING: the records start below f_min = {args.f_min:.0f} Hz, so the "
+        f"conditioning high-pass removes real signal from the beginning. Lower "
+        f"--total_mass so that the whole record sits inside the band."
+    )
+
+record_start = -common_span * geometric_to_seconds
+window_end = -args.align_end_before * geometric_to_seconds
+tau_max = 50.0 * geometric_to_seconds
+
+
+def comparison_window(f_min):
+    """
+    (window, taper_length) for a given analysis f_min.
+
+    The window has to start after the Stage-1 taper: that region is where the
+    conditioning is *supposed* to change the waveform, so including it would be
+    measuring the taper rather than the plugin. The taper length is the same
+    quantity the source model hands to SimInspiralTDConditionStage1.
+    """
+    mass_1, mass_2, spin_1z, spin_2z = component_masses_and_spins(
+        gra.metadata, args.total_mass
+    )
+    _, _, _, chirp_time, extra_time, fraction = compute_conditioning_parameters(
+        dict(mass1=mass_1, mass2=mass_2, spin1z=spin_1z, spin2z=spin_2z, f_lower=f_min)
+    )
+    taper_length = fraction * chirp_time + extra_time
+    start = record_start + taper_length + args.settle_cycles / f_min
+    if start >= window_end:
+        return None, taper_length
+    return numpy.arange(start, window_end, 1.0 / args.srate), taper_length
+
+
+window, taper_length = comparison_window(args.f_min)
+if window is None:
+    raise SystemExit(
+        f"  the Stage-1 taper ({taper_length:.3f} s) leaves nothing of the "
+        f"{-record_start:.3f} s record -- raise --total_mass or --f_min."
+    )
+print(
+    f"  record starts {record_start:.3f} s before merger; Stage-1 taper is "
+    f"{taper_length:.3f} s at f_min = {args.f_min:.0f} Hz\n"
+    f"  comparison window: [{window[0]:+.3f}, {window[-1]:+.3f}] s "
+    f"({window[-1] - window[0]:.3f} s usable)"
+)
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Test 1: before vs after the conditioning
+# ─────────────────────────────────────────────────────────────────────────────
+
+print("\n" + "=" * 78)
+print("Test 1: the same waveform, before and after the LAL conditioning")
+print("=" * 78)
+
+
+def roundtrip(f_min, window):
+    """Same waveform in and out; the only thing acting is the conditioning."""
+    kwargs = gra_arguments(cut_U=gra_kwargs["cut_U"], minimum_frequency=f_min)
+    time, hplus, hcross = nr_time_domain_polarisations(
+        args.total_mass, args.distance, args.iota, args.phase, **kwargs
+    )
+    conditioned = nr_frequency_domain_source_model(
+        frequency_array,
+        args.total_mass,
+        args.distance,
+        args.iota,
+        args.phase,
+        **kwargs,
+    )
+    result = difference_of_polarisations(
+        window,
+        segment_time,
+        to_time_domain(conditioned["plus"]),
+        to_time_domain(conditioned["cross"]),
+        time,
+        hplus,
+        hcross,
+        tau_max,
+    )
+    return time, hplus, hcross, conditioned, result
+
+
+time_before, hplus_before, hcross_before, conditioned, roundtrip_result = roundtrip(
+    args.f_min, window
+)
+hplus_after = to_time_domain(conditioned["plus"])
+hcross_after = to_time_domain(conditioned["cross"])
+
+# Nothing is band-limited by hand here. `after` carries whatever band the
+# conditioning left it with, `before` is the untouched NR waveform, and the
+# window was chosen so the instantaneous frequency is inside [f_min, f_max]
+# throughout -- which is the only region where the two can be expected to agree.
+frequency_in_window = numpy.interp(
+    window,
+    time_before,
+    instantaneous_frequency(time_before, hplus_before, hcross_before),
+)
+print(
+    f"\n  GW frequency over the window: "
+    f"{frequency_in_window.min():.1f} - {frequency_in_window.max():.1f} Hz "
+    f"(band is {args.f_min:.0f} - {args.f_max:.0f} Hz)"
+)
+
+print("\n  after vs before, over the comparison window")
+print("  (tau should come out ~0 -- that is the epoch check. dphi is not")
+print("   meaningful here: the two phases are unwrapped from different origins.)")
+report("conditioned vs raw", roundtrip_result, unit=" s")
+
+# The residual is set by how far the analysis f_min sits below the frequency at
+# which the NR record starts. Above it, the high-pass acts on the whole waveform.
+scan = [value for value in args.f_min_scan if value != args.f_min] + [args.f_min]
+if len(scan) > 1:
+    print(
+        f"\n  the same test at other f_min "
+        f"(the record starts at {gra_frequency / geometric_to_seconds:.1f} Hz):"
+    )
+    print(
+        f"    {'f_min':>6s} {'taper':>8s} {'window':>16s} {'max|dA/A|':>11s} "
+        f"{'max|dphi|':>11s}"
+    )
+    for f_min in sorted(scan):
+        scan_window, scan_taper = comparison_window(f_min)
+        if scan_window is None:
+            print(f"    {f_min:6.0f} {scan_taper:8.3f} {'(nothing left)':>16s}")
+            continue
+        *_, scan_result = roundtrip(f_min, scan_window)
+        print(
+            f"    {f_min:6.0f} {scan_taper:8.3f} "
+            f"{f'[{scan_window[0]:+.2f},{scan_window[-1]:+.2f}]':>16s} "
+            f"{numpy.max(numpy.abs(scan_result['relative_amplitude'])):11.3e} "
+            f"{numpy.max(numpy.abs(scan_result['phase_difference'])):11.3e}"
+        )
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Test 2: GRAthena++ vs SXS, raw and through the plugin
+# ─────────────────────────────────────────────────────────────────────────────
+
+print("\n" + "=" * 78)
+print(f"Test 2: GRAthena:BHBH:{args.gra_id} vs SXS:BBH:{sxs_id}")
+print("=" * 78)
+
+# (a) raw: the (2,2) modes in geometric units, no conditioning anywhere. Same
+# window as (b), expressed in M.
+raw_window = numpy.arange(
+    window[0] / geometric_to_seconds, window[-1] / geometric_to_seconds, 0.5
+)
+raw = difference(
+    raw_window,
+    gra.u - gra_peak,
+    gra.hlm[(2, 2)]["A"],
+    gra.hlm[(2, 2)]["p"],
+    sxs.u - sxs_peak,
+    sxs.hlm[(2, 2)]["A"],
+    sxs.hlm[(2, 2)]["p"],
+    50.0,
+)
+print("\n  (a) raw (2,2) modes, geometric units, no conditioning")
+report("GRA vs SXS", raw, unit=" M")
+
+# (b) through the source model.
+gra_conditioned = nr_frequency_domain_source_model(
+    frequency_array, args.total_mass, args.distance, args.iota, args.phase, **gra_kwargs
+)
+sxs_conditioned = nr_frequency_domain_source_model(
+    frequency_array, args.total_mass, args.distance, args.iota, args.phase, **sxs_kwargs
+)
+plugin = difference_of_polarisations(
+    window,
+    segment_time,
+    to_time_domain(gra_conditioned["plus"]),
+    to_time_domain(gra_conditioned["cross"]),
+    segment_time,
+    to_time_domain(sxs_conditioned["plus"]),
+    to_time_domain(sxs_conditioned["cross"]),
+    tau_max,
+)
+print("\n  (b) through the source model, conditioned and band-limited")
+report("GRA vs SXS", plugin, unit=" s")
+
+# Put the raw difference on the plugin's grid so the two can be subtracted.
+raw_seconds = raw_window * geometric_to_seconds
+raw_phase = numpy.interp(
+    window, raw_seconds, raw["phase_difference"], left=numpy.nan, right=numpy.nan
+)
+raw_amplitude = numpy.interp(
+    window, raw_seconds, raw["relative_amplitude"], left=numpy.nan, right=numpy.nan
+)
+overlap = numpy.isfinite(raw_phase)
+phase_discrepancy = numpy.max(
+    numpy.abs(plugin["phase_difference"][overlap] - raw_phase[overlap])
+)
+amplitude_discrepancy = numpy.max(
+    numpy.abs(plugin["relative_amplitude"][overlap] - raw_amplitude[overlap])
+)
+print("\n  (b) - (a): what the conditioning added on top of the NR difference")
+print(
+    f"      max |dphi_plugin - dphi_raw| = {phase_discrepancy:.3e} rad"
+    f"   (max |dphi_raw| = {numpy.max(numpy.abs(raw['phase_difference'])):.3e})"
+)
+print(
+    f"      max |dA/A_plugin - dA/A_raw| = {amplitude_discrepancy:.3e}"
+    f"   (max |dA/A_raw| = {numpy.max(numpy.abs(raw['relative_amplitude'])):.3e})"
+)
+
+if args.no_plot:
+    raise SystemExit(0)
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Figures
+# ─────────────────────────────────────────────────────────────────────────────
+
+figure, axes = plt.subplots(4, 1, figsize=(9, 12))
+axes[0].plot(time_before, hplus_before, label="before conditioning")
+axes[0].plot(segment_time, hplus_after, "--", label="after conditioning")
+axes[0].axvspan(
+    time_before[0], window[0], color="0.85", zorder=0, label="taper / excluded"
+)
+axes[0].set_xlim(time_before[0], time_before[-1])
+axes[0].set_ylabel(r"$h_+(t)$")
+axes[0].set_xlabel("time to merger [s]")
+axes[0].legend(fontsize=8)
+
+axes[1].semilogy(
+    window, numpy.abs(roundtrip_result["relative_amplitude"]), label=r"$|\Delta A / A|$"
+)
+axes[1].semilogy(
+    window, roundtrip_result["relative_strain"], label=r"$|\Delta h| / |h|$"
+)
+axes[1].set_ylabel("relative difference")
+axes[1].set_xlabel("time to merger [s]")
+axes[1].legend()
+
+axes[2].plot(window, roundtrip_result["phase_difference"])
+axes[2].axhline(0.0, color="k", lw=0.5)
+axes[2].set_ylabel(r"$\Delta \phi$ [rad]")
+axes[2].set_xlabel("time to merger [s]")
+
+axes[3].plot(window, frequency_in_window)
+axes[3].axhline(args.f_min, color="r", lw=0.8, ls="--", label=r"$f_{\min}$")
+axes[3].set_ylabel("GW frequency [Hz]")
+axes[3].set_xlabel("time to merger [s]")
+axes[3].legend()
+
+figure.suptitle(
+    f"Conditioning round trip, GRAthena:BHBH:{args.gra_id}, "
+    f"M = {args.total_mass:.0f} $M_\\odot$"
+)
+figure.tight_layout()
+roundtrip_file = os.path.join(out_path, f"conditioning_roundtrip_{args.gra_id}.png")
+figure.savefig(roundtrip_file, dpi=120)
+
+figure, axes = plt.subplots(3, 1, figsize=(9, 10))
+axes[0].semilogy(gra.u - gra_peak, gra.hlm[(2, 2)]["A"], label=f"GRA:{args.gra_id}")
+axes[0].semilogy(
+    sxs.u - sxs_peak, sxs.hlm[(2, 2)]["A"], "--", label=f"SXS:BBH:{sxs_id}"
+)
+axes[0].axvline(
+    args.t_after_peak,
+    color="r",
+    ls="--",
+    lw=0.8,
+    label=f"trim at +{args.t_after_peak:.0f} M",
+)
+axes[0].set_ylabel(r"$A_{22}$")
+axes[0].set_xlabel(r"$u - u_{\rm peak}$ [M]")
+axes[0].legend(fontsize=8)
+
+axes[1].plot(raw_seconds, raw["relative_amplitude"], label="raw modes")
+axes[1].plot(window, plugin["relative_amplitude"], "--", label="through the plugin")
+axes[1].axhline(0.0, color="k", lw=0.5)
+axes[1].set_ylabel(r"$\Delta A / A$")
+axes[1].set_xlabel("time to merger [s]")
+axes[1].legend()
+
+axes[2].plot(raw_seconds, raw["phase_difference"], label="raw modes")
+axes[2].plot(window, plugin["phase_difference"], "--", label="through the plugin")
+axes[2].axhline(0.0, color="k", lw=0.5)
+axes[2].set_ylabel(r"$\Delta \phi$ [rad]")
+axes[2].set_xlabel("time to merger [s]")
+axes[2].legend()
+
+figure.suptitle(
+    f"GRAthena:BHBH:{args.gra_id} vs SXS:BBH:{sxs_id}, "
+    f"q = {gra.metadata['q']:.2f}, M = {args.total_mass:.0f} $M_\\odot$"
+)
+figure.tight_layout()
+cross_code_file = os.path.join(out_path, f"nr_cross_code_{args.gra_id}.png")
+figure.savefig(cross_code_file, dpi=120)
+
+print(f"\nsaved {roundtrip_file}")
+print(f"saved {cross_code_file}")

--- a/examples/bilby_nr_source_model.py
+++ b/examples/bilby_nr_source_model.py
@@ -49,7 +49,9 @@ parser.add_argument(
     "--sxs-id", default=None, help="SXS ID (default: the partner of --gra-id)"
 )
 parser.add_argument("--res", default="128", help="GRAthena++ resolution")
-parser.add_argument("--ext", default="CCE", help="GRAthena++ extraction: ext, CCE or finite")
+parser.add_argument(
+    "--ext", default="CCE", help="GRAthena++ extraction: ext, CCE or finite"
+)
 parser.add_argument("--r-ext", default="50.00", help="GRAthena++ extraction radius")
 parser.add_argument(
     "--total_mass",

--- a/examples/bilby_nr_source_model.py
+++ b/examples/bilby_nr_source_model.py
@@ -18,16 +18,13 @@ import matplotlib
 
 matplotlib.use("Agg")
 import matplotlib.pyplot as plt
-from scipy.optimize import minimize_scalar
 
 import lal
 
 from PyART.logging_config import setup_logging
-from PyART.utils.wf_utils import align_phase
+from PyART.utils.wf_utils import Align, compute_conditioning_parameters, remap
 from PyART.plugin.bilby_plugin import (
     component_masses_and_spins,
-    compute_conditioning_parameters,
-    estimate_time_of_maximum_amplitude,
     load_nr_waveform,
     nr_frequency_domain_source_model,
     nr_time_domain_polarisations,
@@ -202,13 +199,12 @@ def amplitude_and_phase(hplus, hcross):
     """
     A and phi of h = h+ - i hx, in PyART's convention (h = A exp(-i phi)).
 
-    Face-on this is exact: h is a circularly polarised chirp and A, phi are the
-    amplitude and phase of the (2, 2) mode. Off-axis the higher modes beat
-    against each other and A picks up a modulation -- still well defined, just
-    less clean to read.
+    This is just wf_utils.remap applied to the polarisations. Face-on it is
+    exact: h is a circularly polarised chirp and A, phi are the amplitude and
+    phase of the (2, 2) mode. Off-axis the higher modes beat against each other
+    and A picks up a modulation -- still well defined, just less clean to read.
     """
-    signal = hplus - 1j * hcross
-    return numpy.abs(signal), -numpy.unwrap(numpy.angle(signal))
+    return remap(hplus, -hcross)
 
 
 def align(window, time_a, phase_a, time_b, phase_b, tau_max):
@@ -217,29 +213,28 @@ def align(window, time_a, phase_a, time_b, phase_b, tau_max):
 
         chi2(tau) = int_window [ phi_a(t + tau) - phi_b(t) - dphi ]^2 dt
 
-    over the time shift tau and the phase offset dphi. dphi is solved
-    analytically at each tau by PyART.utils.wf_utils.align_phase; tau comes from
-    a bounded scalar minimisation, so it is sub-sample rather than limited to the
-    grid spacing (which is what PyART's own wf_utils.Align loop gives).
+    over the time shift tau and the phase offset dphi, with
+    PyART.utils.wf_utils.Align(refine=True): a scan on the grid to find the
+    global basin, then a bounded polish for a sub-sample tau.
 
     Returns (tau, dphi): evaluate a at t + tau and subtract dphi from its phase.
     """
-    # align_phase weights on (t >= 0) & (t < Tf), so hand it a shifted window
-    local = window - window[0]
+    # Align weights on (t >= 0) & (t < Tf), so shift everything by window[0] and
+    # let Tf run one sample past the end, which covers the whole window.
+    origin = window[0]
+    local = window - origin
     final = local[-1] + (local[1] - local[0])
-    resampled_b = numpy.interp(window, time_b, phase_b)
-
-    def chi2(tau):
-        shifted_a = numpy.interp(window, time_a + tau, phase_a)
-        offset = align_phase(local, final, shifted_a, resampled_b)
-        return float(numpy.sum((shifted_a - resampled_b - offset) ** 2))
-
-    solution = minimize_scalar(
-        chi2, bounds=(-tau_max, tau_max), method="bounded", options={"xatol": 1e-12}
+    tau, dphi, _ = Align(
+        local,
+        final,
+        tau_max,
+        time_a - origin,
+        phase_a,
+        time_b - origin,
+        phase_b,
+        refine=True,
     )
-    tau = float(solution.x)
-    shifted_a = numpy.interp(window, time_a + tau, phase_a)
-    return tau, float(align_phase(local, final, shifted_a, resampled_b))
+    return float(tau), float(dphi)
 
 
 def difference(
@@ -330,7 +325,7 @@ if abs(gra.metadata["q"] - sxs.metadata["q"]) > 1e-3:
 def record_geometry(waveform):
     """(u_start, u_peak, f_gw22 at the start) in geometric units."""
     modes = sorted(waveform.hlm.keys())
-    peak = estimate_time_of_maximum_amplitude(waveform.u, waveform.hlm, modes)
+    peak = waveform.find_max(kind="argmax", modes=modes, refine=True)[0]
     n_edge = min(64, len(waveform.u) // 4)
     frequency = numpy.abs(
         numpy.median(
@@ -396,11 +391,11 @@ def comparison_window(f_min):
     measuring the taper rather than the plugin. The taper length is the same
     quantity the source model hands to SimInspiralTDConditionStage1.
     """
-    mass_1, mass_2, spin_1z, spin_2z = component_masses_and_spins(
+    mass_1, mass_2, spin_1, spin_2, _ = component_masses_and_spins(
         gra.metadata, args.total_mass
     )
     _, _, _, chirp_time, extra_time, fraction = compute_conditioning_parameters(
-        dict(mass1=mass_1, mass2=mass_2, spin1z=spin_1z, spin2z=spin_2z, f_lower=f_min)
+        mass_1, mass_2, spin_1[2], spin_2[2], f_min
     )
     taper_length = fraction * chirp_time + extra_time
     start = record_start + taper_length + args.settle_cycles / f_min

--- a/tests/test_bilby_plugin.py
+++ b/tests/test_bilby_plugin.py
@@ -1,0 +1,540 @@
+"""
+Tests for the bilby NR source models in PyART.plugin.bilby_plugin.
+
+Everything here runs against a synthetic in-memory Waveform injected in place of
+the catalogue loader, so nothing touches the network or the local_data
+directory.
+"""
+
+import inspect
+
+import numpy as np
+import pytest
+
+from PyART import waveform
+from PyART.utils import utils as ut
+from PyART.utils import wf_utils
+
+pytest.importorskip("lal", reason="LAL not installed")
+
+from PyART.plugin import bilby_plugin  # noqa: E402
+
+TOTAL_MASS = 300.0
+DISTANCE = 400.0
+IOTA = 1.2
+PHASE = 0.35
+SAMPLING_FREQUENCY = 4096.0
+MINIMUM_FREQUENCY = 20.0
+MAXIMUM_FREQUENCY = 1024.0
+DURATION = 32.0
+
+
+def make_metadata(m1=0.6, m2=0.4, spin_1=(0.1, 0.2, 0.3), spin_2=(-0.15, 0.05, -0.2)):
+    metadata = {"m1": m1, "m2": m2, "q": max(m1, m2) / min(m1, m2)}
+    for label, spin in ((1, spin_1), (2, spin_2)):
+        for component, value in zip("xyz", spin):
+            metadata[f"chi{label}{component}"] = value
+    return metadata
+
+
+def make_waveform(
+    metadata=None, modes=((2, 2), (2, -2), (3, 3), (3, -3)), u_max=20000.0
+):
+    """
+    A long, slowly chirping synthetic NR waveform in geometric units.
+
+    It has to be long enough in seconds that the SimInspiralFD conditioning
+    taper fits inside it at TOTAL_MASS.
+    """
+    wf = waveform.Waveform()
+    u = np.arange(0.0, u_max, 0.5)
+    envelope = np.exp(-(((u - 0.85 * u_max) / (0.06 * u_max)) ** 2))
+    orbital_phase = 0.012 * u + 2.0e-7 * u**2
+
+    hlm = {}
+    for ell, emm in modes:
+        amplitude = envelope * (1.0 if ell == 2 else 0.3)
+        hlm[(ell, emm)] = wf_utils.get_multipole_dict(
+            amplitude * np.exp(-1j * emm * orbital_phase)
+        )
+
+    wf._u = u
+    wf._t = u.copy()
+    wf._hlm = hlm
+    wf._domain = "Time"
+    wf._units = "geom"
+    wf.metadata = metadata if metadata is not None else make_metadata()
+    return wf
+
+
+@pytest.fixture
+def waveform_arguments():
+    return dict(
+        catalog="sxs",
+        ID="0001",
+        path="/nonexistent",
+        minimum_frequency=MINIMUM_FREQUENCY,
+        maximum_frequency=MAXIMUM_FREQUENCY,
+        sampling_frequency=SAMPLING_FREQUENCY,
+    )
+
+
+@pytest.fixture
+def frequency_array():
+    return np.arange(0.0, SAMPLING_FREQUENCY / 2 + 1.0 / DURATION, 1.0 / DURATION)
+
+
+@pytest.fixture
+def patched_loader(monkeypatch):
+    """Replace the catalogue loader with a cached synthetic waveform."""
+
+    def install(wf):
+        calls = {"n": 0}
+
+        def fake_loader(**kwargs):
+            calls["n"] += 1
+            return wf
+
+        monkeypatch.setattr(bilby_plugin, "load_nr_waveform", fake_loader)
+        return calls
+
+    yield install
+    bilby_plugin.clear_waveform_cache()
+
+
+##############################
+# component_masses_and_spins
+##############################
+
+
+def test_label_switch_follows_the_lal_convention():
+    """
+    Port of PrecessingNRSur_switch_labels_if_needed: when m1 < m2 the labels are
+    exchanged, the in-plane spin components are swapped AND negated, and the z
+    components are swapped as they are.
+    """
+    spin_1, spin_2 = (0.1, 0.2, 0.3), (-0.15, 0.05, -0.2)
+    metadata = make_metadata(m1=0.4, m2=0.6, spin_1=spin_1, spin_2=spin_2)
+
+    mass_1, mass_2, new_1, new_2, switched = bilby_plugin.component_masses_and_spins(
+        metadata, TOTAL_MASS
+    )
+
+    assert switched is True
+    assert mass_1 > mass_2
+    assert mass_1 == pytest.approx(0.6 * TOTAL_MASS)
+    assert mass_2 == pytest.approx(0.4 * TOTAL_MASS)
+    assert np.allclose(new_1, [-spin_2[0], -spin_2[1], spin_2[2]])
+    assert np.allclose(new_2, [-spin_1[0], -spin_1[1], spin_1[2]])
+
+
+def test_no_label_switch_when_already_ordered():
+    spin_1, spin_2 = (0.1, 0.2, 0.3), (-0.15, 0.05, -0.2)
+    metadata = make_metadata(m1=0.6, m2=0.4, spin_1=spin_1, spin_2=spin_2)
+
+    mass_1, mass_2, new_1, new_2, switched = bilby_plugin.component_masses_and_spins(
+        metadata, TOTAL_MASS
+    )
+
+    assert switched is False
+    assert mass_1 > mass_2
+    assert np.allclose(new_1, spin_1)
+    assert np.allclose(new_2, spin_2)
+
+
+def test_label_switch_maps_relabelled_metadata_onto_the_same_parameters():
+    """
+    Metadata and its label-exchanged twin describe the same physical binary, so
+    the LAL-ordered parameters must come out identical. Only the flag differs,
+    since only one of the two needed the rotation.
+    """
+    spin_1, spin_2 = (0.1, 0.2, 0.3), (-0.15, 0.05, -0.2)
+    original = make_metadata(m1=0.4, m2=0.6, spin_1=spin_1, spin_2=spin_2)
+    relabelled = make_metadata(
+        m1=0.6,
+        m2=0.4,
+        spin_1=(-spin_2[0], -spin_2[1], spin_2[2]),
+        spin_2=(-spin_1[0], -spin_1[1], spin_1[2]),
+    )
+
+    a = bilby_plugin.component_masses_and_spins(original, TOTAL_MASS)
+    b = bilby_plugin.component_masses_and_spins(relabelled, TOTAL_MASS)
+
+    assert a[0] == pytest.approx(b[0])
+    assert a[1] == pytest.approx(b[1])
+    assert np.allclose(a[2], b[2])
+    assert np.allclose(a[3], b[3])
+    assert a[4] is True and b[4] is False
+
+
+def test_label_switch_masses_sum_to_the_total():
+    metadata = make_metadata(m1=0.3, m2=0.7)
+    mass_1, mass_2, *_ = bilby_plugin.component_masses_and_spins(metadata, TOTAL_MASS)
+    assert mass_1 + mass_2 == pytest.approx(TOTAL_MASS)
+
+
+##############################
+# the odd-m rotation
+##############################
+
+
+def test_even_m_modes_are_insensitive_to_the_label_switch(
+    patched_loader, waveform_arguments
+):
+    """A pi rotation about z leaves the even-m modes alone."""
+    modes = ((2, 2), (2, -2))
+    patched_loader(make_waveform(make_metadata(m1=0.6, m2=0.4), modes=modes))
+    _, hp_ordered, hc_ordered = bilby_plugin.nr_time_domain_polarisations(
+        TOTAL_MASS, DISTANCE, IOTA, PHASE, **waveform_arguments
+    )
+
+    patched_loader(make_waveform(make_metadata(m1=0.4, m2=0.6), modes=modes))
+    _, hp_switched, hc_switched = bilby_plugin.nr_time_domain_polarisations(
+        TOTAL_MASS, DISTANCE, IOTA, PHASE, **waveform_arguments
+    )
+
+    # the strain is of order 1e-21, so atol must be 0 for this to mean anything
+    scale = np.max(np.abs(hp_ordered))
+    assert scale > 0.0
+    assert np.allclose(hp_ordered, hp_switched, rtol=1e-12, atol=0.0)
+    assert np.allclose(hc_ordered, hc_switched, rtol=1e-12, atol=0.0)
+
+
+def test_odd_m_modes_flip_sign_under_the_label_switch(
+    patched_loader, waveform_arguments
+):
+    """
+    LALSimIMRPrecessingNRSur.c undoes the relabelling rotation by multiplying
+    the odd-m modes by -1. With only (3, +-3) loaded, the whole waveform flips.
+    """
+    modes = ((3, 3), (3, -3))
+    patched_loader(make_waveform(make_metadata(m1=0.6, m2=0.4), modes=modes))
+    _, hp_ordered, hc_ordered = bilby_plugin.nr_time_domain_polarisations(
+        TOTAL_MASS, DISTANCE, IOTA, PHASE, **waveform_arguments
+    )
+
+    patched_loader(make_waveform(make_metadata(m1=0.4, m2=0.6), modes=modes))
+    _, hp_switched, hc_switched = bilby_plugin.nr_time_domain_polarisations(
+        TOTAL_MASS, DISTANCE, IOTA, PHASE, **waveform_arguments
+    )
+
+    scale = np.max(np.abs(hp_ordered))
+    assert scale > 0.0
+    # atol=0: with the default 1e-8 any two ~1e-21 arrays compare equal
+    assert np.allclose(hp_switched, -hp_ordered, rtol=1e-12, atol=0.0)
+    assert np.allclose(hc_switched, -hc_ordered, rtol=1e-12, atol=0.0)
+    # and the flip is a real change, not a no-op on near-zero data
+    assert np.max(np.abs(hp_switched - hp_ordered)) > scale
+
+
+##############################
+# the cached waveform must survive
+##############################
+
+
+def test_source_model_does_not_mutate_the_cached_waveform(
+    patched_loader, waveform_arguments, frequency_array
+):
+    """
+    The loader memoises, so every likelihood evaluation gets the same object.
+    cut() and to_SI() work in place, and to_SI() raises if called twice, so the
+    plugin has to copy first. This is the regression for that.
+    """
+    wf = make_waveform()
+    patched_loader(wf)
+
+    u_before = wf.u.copy()
+    hlm_before = {k: v["z"].copy() for k, v in wf.hlm.items()}
+    units_before = wf.units
+
+    for _ in range(2):
+        bilby_plugin.nr_frequency_domain_source_model(
+            frequency_array, TOTAL_MASS, DISTANCE, IOTA, PHASE, **waveform_arguments
+        )
+
+    assert np.array_equal(wf.u, u_before)
+    assert wf.units == units_before
+    for key, before in hlm_before.items():
+        assert np.array_equal(wf.hlm[key]["z"], before)
+
+
+def test_repeated_calls_are_reproducible(
+    patched_loader, waveform_arguments, frequency_array
+):
+    patched_loader(make_waveform())
+    first = bilby_plugin.nr_frequency_domain_source_model(
+        frequency_array, TOTAL_MASS, DISTANCE, IOTA, PHASE, **waveform_arguments
+    )
+    second = bilby_plugin.nr_frequency_domain_source_model(
+        frequency_array, TOTAL_MASS, DISTANCE, IOTA, PHASE, **waveform_arguments
+    )
+    assert np.array_equal(first["plus"], second["plus"])
+    assert np.array_equal(first["cross"], second["cross"])
+
+
+##############################
+# time-domain output
+##############################
+
+
+def test_time_domain_peak_sits_at_t_zero(patched_loader, waveform_arguments):
+    """
+    t = 0 goes on the peak of the frame-invariant amplitude. Use a single
+    multipole so |h| is exactly the envelope: with both +m and -m present the
+    two beat against each other and |h| picks up a modulation whose maximum is
+    not the envelope maximum.
+    """
+    patched_loader(make_waveform(modes=((2, 2),)))
+    time, hplus, hcross = bilby_plugin.nr_time_domain_polarisations(
+        TOTAL_MASS, DISTANCE, IOTA, PHASE, **waveform_arguments
+    )
+    peak_time = time[np.argmax(np.abs(hplus - 1j * hcross))]
+    assert abs(peak_time) <= 2.0 / SAMPLING_FREQUENCY
+
+
+def test_time_domain_is_uniformly_sampled(patched_loader, waveform_arguments):
+    patched_loader(make_waveform())
+    time, _, _ = bilby_plugin.nr_time_domain_polarisations(
+        TOTAL_MASS, DISTANCE, IOTA, PHASE, **waveform_arguments
+    )
+    assert np.allclose(np.diff(time), 1.0 / SAMPLING_FREQUENCY)
+
+
+def test_time_domain_amplitude_scales_inversely_with_distance(
+    patched_loader, waveform_arguments
+):
+    patched_loader(make_waveform())
+    _, hplus_near, _ = bilby_plugin.nr_time_domain_polarisations(
+        TOTAL_MASS, DISTANCE, IOTA, PHASE, **waveform_arguments
+    )
+    _, hplus_far, _ = bilby_plugin.nr_time_domain_polarisations(
+        TOTAL_MASS, 2 * DISTANCE, IOTA, PHASE, **waveform_arguments
+    )
+    assert np.max(np.abs(hplus_near)) > 0.0
+    assert np.allclose(hplus_far, 0.5 * hplus_near, rtol=1e-12, atol=0.0)
+
+
+def test_t_after_peak_trims_the_record(patched_loader, waveform_arguments):
+    patched_loader(make_waveform())
+    time_full, _, _ = bilby_plugin.nr_time_domain_polarisations(
+        TOTAL_MASS, DISTANCE, IOTA, PHASE, **waveform_arguments
+    )
+    time_cut, _, _ = bilby_plugin.nr_time_domain_polarisations(
+        TOTAL_MASS,
+        DISTANCE,
+        IOTA,
+        PHASE,
+        **{**waveform_arguments, "t_after_peak": 100.0},
+    )
+    assert time_cut[-1] < time_full[-1]
+    # 100 M after the peak, in seconds. The cut lands on the source grid (0.5 M)
+    # and the resampling then truncates to the last whole 1/srate step.
+    geometric_to_seconds = TOTAL_MASS * ut.consts["Msun"]
+    assert time_cut[-1] == pytest.approx(
+        100.0 * geometric_to_seconds,
+        abs=0.5 * geometric_to_seconds + 2.0 / SAMPLING_FREQUENCY,
+    )
+
+
+def test_mode_array_selects_a_subset(patched_loader, waveform_arguments):
+    patched_loader(make_waveform())
+    _, hplus_all, _ = bilby_plugin.nr_time_domain_polarisations(
+        TOTAL_MASS, DISTANCE, IOTA, PHASE, **waveform_arguments
+    )
+    _, hplus_22, _ = bilby_plugin.nr_time_domain_polarisations(
+        TOTAL_MASS,
+        DISTANCE,
+        IOTA,
+        PHASE,
+        **{**waveform_arguments, "mode_array": [(2, 2), (2, -2)]},
+    )
+    # atol=0: the strain is of order 1e-21, so the default atol=1e-8 would call
+    # any two of these arrays equal
+    assert not np.allclose(hplus_all, hplus_22, atol=0.0)
+    peak = np.max(np.abs(hplus_all))
+    assert np.max(np.abs(hplus_all - hplus_22)) > 1e-3 * peak
+
+
+def test_unknown_mode_raises(patched_loader, waveform_arguments):
+    patched_loader(make_waveform())
+    with pytest.raises(KeyError, match=r"\(5, 5\)"):
+        bilby_plugin.nr_time_domain_polarisations(
+            TOTAL_MASS,
+            DISTANCE,
+            IOTA,
+            PHASE,
+            **{**waveform_arguments, "mode_array": [(5, 5)]},
+        )
+
+
+##############################
+# frequency-domain output
+##############################
+
+
+def test_frequency_domain_is_zero_outside_the_band(
+    patched_loader, waveform_arguments, frequency_array
+):
+    patched_loader(make_waveform())
+    strain = bilby_plugin.nr_frequency_domain_source_model(
+        frequency_array, TOTAL_MASS, DISTANCE, IOTA, PHASE, **waveform_arguments
+    )
+    outside = (frequency_array < MINIMUM_FREQUENCY) | (
+        frequency_array > MAXIMUM_FREQUENCY
+    )
+    assert np.all(strain["plus"][outside] == 0.0)
+    assert np.all(strain["cross"][outside] == 0.0)
+    assert np.any(strain["plus"][~outside] != 0.0)
+
+
+def test_frequency_domain_shape_matches_the_input_grid(
+    patched_loader, waveform_arguments, frequency_array
+):
+    patched_loader(make_waveform())
+    strain = bilby_plugin.nr_frequency_domain_source_model(
+        frequency_array, TOTAL_MASS, DISTANCE, IOTA, PHASE, **waveform_arguments
+    )
+    assert strain["plus"].shape == frequency_array.shape
+    assert strain["cross"].shape == frequency_array.shape
+    assert np.iscomplexobj(strain["plus"])
+
+
+def test_frequency_domain_raises_on_a_record_shorter_than_the_taper(
+    patched_loader, waveform_arguments, frequency_array
+):
+    # the Stage-1 taper is ~0.51 s here; 300 M at TOTAL_MASS is only ~0.44 s
+    patched_loader(make_waveform(u_max=300.0))
+    with pytest.raises(ValueError, match="conditioning wants to taper"):
+        bilby_plugin.nr_frequency_domain_source_model(
+            frequency_array, TOTAL_MASS, DISTANCE, IOTA, PHASE, **waveform_arguments
+        )
+
+
+##############################
+# loading, caching, dispatch
+##############################
+
+
+def test_unknown_catalog_raises_a_plain_error():
+    with pytest.raises(NotImplementedError) as excinfo:
+        bilby_plugin.load_nr_waveform(catalog="nonesuch", ID="0001", path="/tmp")
+
+    message = str(excinfo.value)
+    assert "not implemented" in message
+    assert "nonesuch" in message
+    # the message used to name a maintainer and tell the user to pester them
+    assert "Koustav" not in message
+
+
+def test_clear_waveform_cache_empties_the_cache():
+    bilby_plugin._WAVEFORM_CACHE[("sentinel",)] = object()
+    assert bilby_plugin._WAVEFORM_CACHE
+    bilby_plugin.clear_waveform_cache()
+    assert not bilby_plugin._WAVEFORM_CACHE
+
+
+def test_loader_is_called_once_per_source_model_evaluation(
+    patched_loader, waveform_arguments, frequency_array
+):
+    calls = patched_loader(make_waveform())
+    bilby_plugin.nr_frequency_domain_source_model(
+        frequency_array, TOTAL_MASS, DISTANCE, IOTA, PHASE, **waveform_arguments
+    )
+    # once in the FD model for the metadata, once in the TD helper
+    assert calls["n"] == 2
+
+
+##############################
+# the per-catalogue wrappers
+##############################
+
+
+@pytest.mark.parametrize(
+    "wrapper, catalog",
+    [
+        (bilby_plugin.sxs_frequency_domain_source_model, "sxs"),
+        (bilby_plugin.gra_frequency_domain_source_model, "gra"),
+    ],
+)
+def test_catalogue_wrappers_pin_the_catalog(
+    wrapper, catalog, patched_loader, waveform_arguments, frequency_array, monkeypatch
+):
+    patched_loader(make_waveform())
+    seen = {}
+
+    def spy(frequency_array, *args, **kwargs):
+        seen.update(kwargs)
+        return dict(plus=frequency_array * 0j, cross=frequency_array * 0j)
+
+    monkeypatch.setattr(bilby_plugin, "nr_frequency_domain_source_model", spy)
+
+    arguments = {k: v for k, v in waveform_arguments.items() if k != "catalog"}
+    wrapper(frequency_array, TOTAL_MASS, DISTANCE, IOTA, PHASE, **arguments)
+
+    assert seen["catalog"] == catalog
+
+
+@pytest.mark.parametrize(
+    "wrapper",
+    [
+        bilby_plugin.sxs_frequency_domain_source_model,
+        bilby_plugin.gra_frequency_domain_source_model,
+    ],
+)
+def test_catalogue_wrappers_do_not_mutate_the_caller_arguments(
+    wrapper, patched_loader, waveform_arguments, frequency_array
+):
+    patched_loader(make_waveform())
+    arguments = {k: v for k, v in waveform_arguments.items() if k != "catalog"}
+    before = dict(arguments)
+
+    wrapper(frequency_array, TOTAL_MASS, DISTANCE, IOTA, PHASE, **arguments)
+
+    assert arguments == before
+    assert "catalog" not in arguments
+
+
+@pytest.mark.parametrize(
+    "wrapper",
+    [
+        bilby_plugin.sxs_frequency_domain_source_model,
+        bilby_plugin.gra_frequency_domain_source_model,
+    ],
+)
+def test_catalogue_wrappers_keep_the_generic_signature(wrapper):
+    """
+    bilby introspects the source model to decide which sampled parameters to
+    pass, so the wrappers must expose the same parameters as the generic model.
+    This is why they are plain functions and not functools.partial objects.
+    """
+    generic = inspect.signature(bilby_plugin.nr_frequency_domain_source_model)
+    assert inspect.signature(wrapper).parameters.keys() == generic.parameters.keys()
+
+
+@pytest.mark.parametrize(
+    "wrapper, catalog",
+    [
+        (bilby_plugin.sxs_frequency_domain_source_model, "sxs"),
+        (bilby_plugin.gra_frequency_domain_source_model, "gra"),
+    ],
+)
+def test_catalogue_wrappers_match_the_generic_model(
+    wrapper, catalog, patched_loader, waveform_arguments, frequency_array
+):
+    patched_loader(make_waveform())
+    arguments = {k: v for k, v in waveform_arguments.items() if k != "catalog"}
+
+    from_wrapper = wrapper(
+        frequency_array, TOTAL_MASS, DISTANCE, IOTA, PHASE, **arguments
+    )
+    from_generic = bilby_plugin.nr_frequency_domain_source_model(
+        frequency_array,
+        TOTAL_MASS,
+        DISTANCE,
+        IOTA,
+        PHASE,
+        **{**arguments, "catalog": catalog},
+    )
+
+    assert np.array_equal(from_wrapper["plus"], from_generic["plus"])
+    assert np.array_equal(from_wrapper["cross"], from_generic["cross"])


### PR DESCRIPTION
## Summary

This PR adds a Bilby plugin that enables direct use of PyART's NR catalogue within Bilby's `WaveformGenerator`.

```python
import bilby
from PyART.plugin.bilby_plugin import nr_frequency_domain_source_model

waveform_arguments = dict(
    catalog="sxs", ID="0305", path="./local_data/sxs/", download=True,
    ellmax=4, cut_U=200,
    minimum_frequency=20.0, maximum_frequency=1024.0, sampling_frequency=4096.0,
)
waveform_generator = bilby.gw.WaveformGenerator(
    duration=4.0, sampling_frequency=4096.0,
    frequency_domain_source_model=nr_frequency_domain_source_model,
    waveform_arguments=waveform_arguments,
)
```

The plugin currently supports the **SXS** and **GRA** catalogues currently. Other catalogues will be trivial to add. Will add on a need-by basis.

The main thing is that it performs the data conditioning required to produce frequency-domain polarisations compatible with Bilby's `XLALSimInspiralFD` interface, including time-domain conditioning, power-of-two waveform padding, and epoch-aware time shifting.

The plugin is deliberately put outside the main `PyART` import chain since it depends on `lal` and `lalsimulation`, allowing `import PyART` to work without these optional dependencies.

## Validation

Run `examples/bilby_nr_source_model.py` to verify cross-catalogue consistency.

| Comparison | Max. ΔA/A | Max. Δφ (rad) |
|-------------|----------:|--------------:|
| Raw modes (GRA vs. SXS) | 6.1e-3 | 3.5e-3 |
| Through Bilby source model | 4.4e-3 | 2.5e-3 |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Bilby-compatible source models for SXS and GRAthena++ numerical-relativity waveforms.
  * Added waveform loading, mode selection, conditioning, polarisation conversion, caching, and frequency-domain generation.
  * Added improved waveform copying, interpolation, unit conversion, amplitude analysis, extremum refinement, and alignment.
  * Added validation for unsupported catalogues, missing modes, and insufficient waveform duration.

* **Documentation**
  * Documented optional plugin loading.

* **Examples**
  * Added a command-line example for comparing source models with optional diagnostic plots.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->